### PR TITLE
fix: specify content-type in the GET /rss/[feed] endpoint

### DIFF
--- a/n2rss.http
+++ b/n2rss.http
@@ -8,3 +8,6 @@ X-Secret-Key: pouet
 ### Stop server (success)
 POST http://localhost:8080/stop
 X-Secret-Key: abcd
+
+### Content-Type
+GET http://localhost:8080/rss/pointer

--- a/src/main/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedController.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedController.kt
@@ -57,7 +57,7 @@ class RssFeedController(
      */
     @GetMapping(
         "{feed}",
-        produces = [MediaType.APPLICATION_XML_VALUE]
+        produces = [MediaType.APPLICATION_RSS_XML_VALUE],
     )
     fun getFeed(
         @PathVariable("feed") code: String,
@@ -98,6 +98,7 @@ class RssFeedController(
                     }
             }
 
+        response.contentType = MediaType.APPLICATION_RSS_XML_VALUE
         rssOutputWriter.write(feed, response)
     }
 }


### PR DESCRIPTION
Attempt to fix the incompatibility with Feeder (see issue #9)