### PR TITLE
feat: add support for 1-level hierarchical feeds

### DIFF
--- a/src/main/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedController.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedController.kt
@@ -58,6 +58,39 @@ class RssFeedController(
         @RequestParam(value = "publicationCount", defaultValue = "2") publicationCount: Int,
         response: HttpServletResponse,
     ) {
+        writeFeedToResponse(code, publicationStart, publicationCount, response)
+    }
+
+    /**
+     * Retrieves the RSS feed of publications, for feeds whose type is of format "folder/code"
+     *
+     * @param folder folder part of the code associated with the feed
+     * @param feed feed part of the code associated with the feed
+     * @param publicationStart The starting index of publications to retrieve. Default is 0.
+     * @param publicationCount The maximum number of publications to retrieve. Default is 2.
+     * @param response The HttpServletResponse object used for writing the feed to the response output stream.
+     */
+    @GetMapping(
+        "{folder}/{feed}",
+        produces = [RSS_CONTENT_TYPE],
+    )
+    fun getFeed(
+        @PathVariable("folder") folder: String,
+        @PathVariable("feed") feed: String,
+        @RequestParam(value = "publicationStart", defaultValue = "0") publicationStart: Int,
+        @RequestParam(value = "publicationCount", defaultValue = "2") publicationCount: Int,
+        response: HttpServletResponse,
+    ) {
+        val code = "$folder/$feed"
+        writeFeedToResponse(code, publicationStart, publicationCount, response)
+    }
+
+    private fun writeFeedToResponse(
+        code: String,
+        publicationStart: Int,
+        publicationCount: Int,
+        response: HttpServletResponse
+    ) {
         try {
             val feed = rssService.getFeed(code, publicationStart, publicationCount)
             response.contentType = RSS_CONTENT_TYPE

--- a/src/test/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedControllerTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedControllerTest.kt
@@ -103,6 +103,24 @@ class RssFeedControllerTest {
     }
 
     @Test
+    fun `getFeed should return an RSS feed for feed inside a folder`() {
+        // GIVEN
+        val mockResponse = mockk<HttpServletResponse>(relaxed = true)
+
+        val feed = mockk<SyndFeed>()
+        every { rssService.getFeed(any(), any(), any()) } returns feed
+
+        // WHEN
+        rssFeedController.getFeed("folder", "test", 0, 2, mockResponse)
+
+        // THEN
+        verifySequence {
+            rssService.getFeed("folder/test", 0, 2)
+            rssOutputWriter.write(feed, any())
+        }
+    }
+
+    @Test
     fun `getFeed should return a 404 error if the feed does not exist`() {
         // GIVEN
         val mockResponse = mockk<HttpServletResponse>(relaxed = true)


### PR DESCRIPTION
feeds can be grouped in a folder like "/rss/folder/feed"