### PR TITLE
chore: update dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
     id("io.spring.dependency-management") version "1.1.5"
     kotlin("jvm") version "1.9.24"
     kotlin("plugin.spring") version "1.9.24"
-    id("org.jetbrains.kotlinx.kover") version "0.8.0"
+    id("org.jetbrains.kotlinx.kover") version "0.8.1"
     id("io.gitlab.arturbosch.detekt") version("1.23.5")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ import kotlinx.kover.gradle.plugin.dsl.CoverageUnit
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "3.2.5"
+    id("org.springframework.boot") version "3.3.0"
     id("io.spring.dependency-management") version "1.1.5"
     kotlin("jvm") version "1.9.24"
     kotlin("plugin.spring") version "1.9.24"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,7 @@ dependencies {
         exclude(group = "org.mockito")
     }
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.10.2")
-    testImplementation("io.kotest:kotest-assertions-core-jvm:5.9.0")
+    testImplementation("io.kotest:kotest-assertions-core-jvm:5.9.1")
     testImplementation("io.kotest.extensions:kotest-assertions-kotlinx-datetime:1.1.0")
     testImplementation("io.mockk:mockk:1.13.11")
     testImplementation("com.icegreen:greenmail:2.0.1")


### PR DESCRIPTION
- Spring Boot from 3.2.5 to 3.3.0
- Kotest from 5.9.0 to 5.9.1
- Kover from 0.8.0 to 0.8.1