### PR TITLE
chore: rename library feeds

### DIFF
--- a/src/main/kotlin/fr/nicopico/n2rss/mail/newsletter/AndroidWeeklyNewsletterHandler.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/mail/newsletter/AndroidWeeklyNewsletterHandler.kt
@@ -109,7 +109,7 @@ class AndroidWeeklyNewsletterHandler : NewsletterHandlerMultipleFeeds {
         )
 
         val librariesNewsletter = Newsletter(
-            code = "android_weekly/libs",
+            code = "android_weekly/libraries",
             name = "Android Weekly",
             websiteUrl = "https://androidweekly.net",
             notes = "Libraries"

--- a/src/main/kotlin/fr/nicopico/n2rss/mail/newsletter/KotlinWeeklyNewsletterHandler.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/mail/newsletter/KotlinWeeklyNewsletterHandler.kt
@@ -28,7 +28,6 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import org.jsoup.safety.Safelist
 import org.springframework.stereotype.Component
-import kotlin.text.Typography.section
 
 @Component
 class KotlinWeeklyNewsletterHandler : NewsletterHandlerMultipleFeeds {
@@ -115,7 +114,7 @@ class KotlinWeeklyNewsletterHandler : NewsletterHandlerMultipleFeeds {
         )
 
         val librariesNewsletter = Newsletter(
-            code = "kotlin_weekly/libs",
+            code = "kotlin_weekly/libraries",
             name = "Kotlin Weekly",
             websiteUrl = "https://kotlinweekly.net/",
             notes = "Libraries"


### PR DESCRIPTION
android_weekly/libs -> android_weekly/libraries
kotlin_weekly/libs -> kotlin_weekly/libraries