### PR TITLE
feat: collect server-side analytics

### DIFF
--- a/deploy/application.properties
+++ b/deploy/application.properties
@@ -25,8 +25,6 @@ spring.data.mongodb.password=${N2RSS_MONGODB_PASSWORD}
 
 # n2rss
 n2rss.analytics.enabled=true
-n2rss.analytics.hostname=n2rss.nicopico.fr
-n2rss.analytics.user-agent=ServerSide/1.0 (+https://n2rss.nicopico.fr/)
 n2rss.email.cron=${N2RSS_EMAIL_CRON:0 0 * * * *}
 n2rss.email.client.host=${N2RSS_EMAIL_HOST}
 n2rss.email.client.port=${N2RSS_EMAIL_PORT:993}

--- a/n2rss.http
+++ b/n2rss.http
@@ -29,3 +29,15 @@ POST http://localhost:8080/send-request
 Content-Type: application/x-www-form-urlencoded
 
 newsletterUrl = https://www.some.fo/
+
+### Notify release (success)
+POST http://localhost:8080/notifyRelease?version=1.2.3
+X-Secret-Key: abcd
+
+### Notify release (missing version)
+POST http://localhost:8080/notifyRelease
+X-Secret-Key: abcd
+
+### Notify release (wrong key)
+POST http://localhost:8080/notifyRelease?version=1.2.3
+X-Secret-Key: toto

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticAspect.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticAspect.kt
@@ -31,6 +31,20 @@ private val LOG = LoggerFactory.getLogger(AnalyticAspect::class.java)
 class AnalyticAspect(
     private val analyticService: AnalyticService
 ) {
+    @Pointcut(
+        "@annotation(org.springframework.web.bind.annotation.GetMapping)" +
+            "&& execution(* home(..))"
+    )
+    fun homePointcut() = Unit
+
+    @Before("homePointcut()")
+    fun trackHome(joinPoint: JoinPoint) {
+        try {
+            analyticService.track(AnalyticEvent.Home)
+        } catch (e: AnalyticException) {
+            LOG.error("Could not track GetFeed event", e)
+        }
+    }
 
     @Pointcut(
         "@annotation(org.springframework.web.bind.annotation.GetMapping)" +
@@ -39,9 +53,7 @@ class AnalyticAspect(
     fun getFeedPointcut() = Unit
 
     @Before("getFeedPointcut()")
-    fun trackGetFeedAccess(joinPoint: JoinPoint) {
-        // We want to prevent any crash coming from this method
-        @Suppress("TooGenericExceptionCaught")
+    fun trackGetFeed(joinPoint: JoinPoint) {
         try {
             val code = joinPoint.args[0] as String
             analyticService.track(AnalyticEvent.GetFeed(code))
@@ -58,8 +70,6 @@ class AnalyticAspect(
 
     @Before("requestNewsletterPointcut()")
     fun trackRequestNewsletter(joinPoint: JoinPoint) {
-        // We want to prevent any crash coming from this method
-        @Suppress("TooGenericExceptionCaught")
         try {
             val newsletterUrl = joinPoint.args[0] as String
             analyticService.track(AnalyticEvent.RequestNewsletter(newsletterUrl))

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticAspect.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticAspect.kt
@@ -18,6 +18,7 @@
 package fr.nicopico.n2rss.analytics
 
 import fr.nicopico.n2rss.models.Email
+import jakarta.servlet.http.HttpServletResponse
 import org.aspectj.lang.JoinPoint
 import org.aspectj.lang.annotation.AfterThrowing
 import org.aspectj.lang.annotation.Aspect
@@ -70,7 +71,13 @@ class AnalyticAspect(
     fun trackGetFeed(joinPoint: JoinPoint) {
         try {
             val code = extractCode(joinPoint.args)
-            analyticService.track(AnalyticEvent.GetFeed(code))
+            val userAgent = extractUserAgent(joinPoint.args)
+            analyticService.track(
+                AnalyticEvent.GetFeed(
+                    feedCode = code,
+                    userAgent = userAgent,
+                )
+            )
         } catch (e: AnalyticException) {
             LOG.error("Could not track GetFeed event", e)
         }
@@ -92,6 +99,10 @@ class AnalyticAspect(
         } else {
             args[0] as String
         }
+    }
+
+    private fun extractUserAgent(args: Array<Any>): String? {
+        return args.getOrNull(args.indexOfFirst { it is HttpServletResponse } + 1) as? String
     }
     //endregion
 

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticEvent.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticEvent.kt
@@ -49,5 +49,5 @@ sealed class AnalyticEvent {
     /**
      * A new version has been released to production
      */
-    data class Release(val version: String) : AnalyticEvent()
+    data class NewRelease(val version: String) : AnalyticEvent()
 }

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticEvent.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticEvent.kt
@@ -26,7 +26,10 @@ sealed class AnalyticEvent {
     /**
      * A user accessed an RSS feed
      */
-    data class GetFeed(val feedCode: String) : AnalyticEvent()
+    data class GetFeed(
+        val feedCode: String,
+        val userAgent: String?,
+    ) : AnalyticEvent()
 
     /**
      * A user requested support for a newsletter

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticEvent.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticEvent.kt
@@ -18,6 +18,7 @@
 package fr.nicopico.n2rss.analytics
 
 sealed class AnalyticEvent {
+    data object Home : AnalyticEvent()
     data class GetFeed(val code: String) : AnalyticEvent()
     data class RequestNewsletter(val newsletterUrl: String) : AnalyticEvent()
 }

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticEvent.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticEvent.kt
@@ -18,7 +18,33 @@
 package fr.nicopico.n2rss.analytics
 
 sealed class AnalyticEvent {
+    /**
+     * A user accessed the home page
+     */
     data object Home : AnalyticEvent()
-    data class GetFeed(val code: String) : AnalyticEvent()
+
+    /**
+     * A user accessed an RSS feed
+     */
+    data class GetFeed(val feedCode: String) : AnalyticEvent()
+
+    /**
+     * A user requested support for a newsletter
+     */
     data class RequestNewsletter(val newsletterUrl: String) : AnalyticEvent()
+
+    sealed class Error : AnalyticEvent() {
+        data object HomeError : Error()
+        data class GetFeedError(val feedCode: String) : Error()
+        data object RequestNewsletterError : Error()
+        data class EmailParsingError(
+            val handlerName: String,
+            val emailTitle: String
+        ) : Error()
+    }
+
+    /**
+     * A new version has been released to production
+     */
+    data class Release(val version: String) : AnalyticEvent()
 }

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticService.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticService.kt
@@ -17,12 +17,10 @@
  */
 package fr.nicopico.n2rss.analytics
 
-import fr.nicopico.n2rss.analytics.data.AnalyticsData
-import fr.nicopico.n2rss.analytics.data.AnalyticsDataCode
 import fr.nicopico.n2rss.analytics.data.AnalyticsRepository
+import fr.nicopico.n2rss.analytics.data.toAnalyticsData
 import fr.nicopico.n2rss.config.N2RssProperties
 import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
@@ -51,26 +49,6 @@ class AnalyticService(
             } catch (e: Exception) {
                 throw AnalyticException("Unable to send analytics event $event", e)
             }
-        }
-    }
-
-    private fun AnalyticEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
-        return when (this) {
-            is AnalyticEvent.GetFeed -> AnalyticsData(
-                code = AnalyticsDataCode.GET_FEED,
-                data = code,
-                timestamp = timestamp,
-            )
-
-            is AnalyticEvent.Home -> AnalyticsData(
-                code = AnalyticsDataCode.HOME,
-                timestamp = timestamp,
-            )
-            is AnalyticEvent.RequestNewsletter -> AnalyticsData(
-                code = AnalyticsDataCode.REQUEST_NEWSLETTER,
-                data = newsletterUrl,
-                timestamp = timestamp,
-            )
         }
     }
 }

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticService.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticService.kt
@@ -17,96 +17,26 @@
  */
 package fr.nicopico.n2rss.analytics
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import fr.nicopico.n2rss.config.N2RssProperties
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.web.client.HttpClientErrorException
-import org.springframework.web.client.RestClient
 
 private val LOG = LoggerFactory.getLogger(AnalyticService::class.java)
 
 @Service
 class AnalyticService(
-    restClientBuilder: RestClient.Builder = RestClient.builder(),
-    private val analyticsApiBaseUrl: String,
     private val analyticsProperties: N2RssProperties.AnalyticsProperties,
 ) {
-    @Autowired
-    constructor(
-        restClientBuilder: RestClient.Builder,
-        analyticsProperties: N2RssProperties.AnalyticsProperties,
-    ) : this(
-        restClientBuilder = restClientBuilder,
-        analyticsApiBaseUrl = "https://queue.simpleanalyticscdn.com",
-        analyticsProperties = analyticsProperties,
-    )
-
-    private val restClient by lazy {
-        restClientBuilder
-            .baseUrl(analyticsApiBaseUrl)
-            .build()
-    }
-
     @Throws(AnalyticException::class)
     fun track(event: AnalyticEvent) {
         if (analyticsProperties.enabled) {
             LOG.info("TRACK: $event")
             try {
-                restClient
-                    .post()
-                    .uri("/events")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .body(event.toSimpleAnalyticsEvent())
-                    .retrieve()
-                    .toBodilessEntity()
+                TODO("Track event")
             } catch (e: HttpClientErrorException) {
                 throw AnalyticException("Unable to send analytics event $event", e)
             }
         }
     }
-
-    private fun AnalyticEvent.toSimpleAnalyticsEvent(): SimpleAnalyticsEvent {
-        return SimpleAnalyticsEvent(
-            type = "event",
-            hostname = analyticsProperties.hostname,
-            event = when (this) {
-                is AnalyticEvent.GetFeed -> EVENT_GET_FEED
-                is AnalyticEvent.RequestNewsletter -> EVENT_REQUEST_NEWSLETTER
-            },
-            ua = analyticsProperties.userAgent,
-            metadata = when (this) {
-                is AnalyticEvent.GetFeed -> mapOf(
-                    METADATA_GET_FEED_CODE to code
-                )
-
-                is AnalyticEvent.RequestNewsletter -> mapOf(
-                    METADATA_REQUEST_NEWSLETTER_URL to newsletterUrl
-                )
-            }
-        )
-    }
-
-    companion object {
-        private const val EVENT_GET_FEED = "get-feed"
-        private const val EVENT_REQUEST_NEWSLETTER = "request-newsletter"
-
-        private const val METADATA_GET_FEED_CODE = "get-feed-code"
-        private const val METADATA_REQUEST_NEWSLETTER_URL = "request-newsletter-url"
-    }
 }
-
-private data class SimpleAnalyticsEvent(
-    @JsonProperty("type")
-    val type: String,
-    @JsonProperty("hostname")
-    val hostname: String,
-    @JsonProperty("event")
-    val event: String,
-    @JsonProperty("ua")
-    val ua: String,
-    @JsonProperty("metadata")
-    val metadata: Map<String, String>
-)

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspect.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspect.kt
@@ -27,12 +27,12 @@ import org.aspectj.lang.annotation.Pointcut
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
-private val LOG = LoggerFactory.getLogger(AnalyticAspect::class.java)
+private val LOG = LoggerFactory.getLogger(AnalyticsAspect::class.java)
 
 @Aspect
 @Component
-class AnalyticAspect(
-    private val analyticService: AnalyticService
+class AnalyticsAspect(
+    private val analyticsService: AnalyticsService
 ) {
     //region Home
     @Pointcut(
@@ -44,8 +44,8 @@ class AnalyticAspect(
     @Before("homePointcut()")
     fun trackHome(joinPoint: JoinPoint) {
         try {
-            analyticService.track(AnalyticEvent.Home)
-        } catch (e: AnalyticException) {
+            analyticsService.track(AnalyticsEvent.Home)
+        } catch (e: AnalyticsException) {
             LOG.error("Could not track Home event", e)
         }
     }
@@ -53,8 +53,8 @@ class AnalyticAspect(
     @AfterThrowing("homePointcut()", throwing = "error")
     fun homeError(joinPoint: JoinPoint, error: Exception) {
         try {
-            analyticService.track(AnalyticEvent.Error.HomeError)
-        } catch (e: AnalyticException) {
+            analyticsService.track(AnalyticsEvent.Error.HomeError)
+        } catch (e: AnalyticsException) {
             LOG.error("Could not track HomeError event", e)
         }
     }
@@ -72,13 +72,13 @@ class AnalyticAspect(
         try {
             val code = extractCode(joinPoint.args)
             val userAgent = extractUserAgent(joinPoint.args)
-            analyticService.track(
-                AnalyticEvent.GetFeed(
+            analyticsService.track(
+                AnalyticsEvent.GetFeed(
                     feedCode = code,
                     userAgent = userAgent,
                 )
             )
-        } catch (e: AnalyticException) {
+        } catch (e: AnalyticsException) {
             LOG.error("Could not track GetFeed event", e)
         }
     }
@@ -87,8 +87,8 @@ class AnalyticAspect(
     fun getFeedError(joinPoint: JoinPoint, error: Exception) {
         try {
             val code = extractCode(joinPoint.args)
-            analyticService.track(AnalyticEvent.Error.GetFeedError(code))
-        } catch (e: AnalyticException) {
+            analyticsService.track(AnalyticsEvent.Error.GetFeedError(code))
+        } catch (e: AnalyticsException) {
             LOG.error("Could not track GetFeedError event", e)
         }
     }
@@ -117,8 +117,8 @@ class AnalyticAspect(
     fun trackRequestNewsletter(joinPoint: JoinPoint) {
         try {
             val newsletterUrl = joinPoint.args[0] as String
-            analyticService.track(AnalyticEvent.RequestNewsletter(newsletterUrl))
-        } catch (e: AnalyticException) {
+            analyticsService.track(AnalyticsEvent.RequestNewsletter(newsletterUrl))
+        } catch (e: AnalyticsException) {
             LOG.error("Could not track RequestNewsletter event", e)
         }
     }
@@ -126,8 +126,8 @@ class AnalyticAspect(
     @AfterThrowing("requestNewsletterPointcut()", throwing = "error")
     fun requestNewsletterError(joinPoint: JoinPoint, error: Exception) {
         try {
-            analyticService.track(AnalyticEvent.Error.RequestNewsletterError)
-        } catch (e: AnalyticException) {
+            analyticsService.track(AnalyticsEvent.Error.RequestNewsletterError)
+        } catch (e: AnalyticsException) {
             LOG.error("Could not track RequestNewsletterError event", e)
         }
     }
@@ -143,13 +143,13 @@ class AnalyticAspect(
             val email = joinPoint.args[0] as Email
             val newsletterHandlerName = (joinPoint.target).javaClass.simpleName
             val emailTitle = email.subject
-            analyticService.track(
-                AnalyticEvent.Error.EmailParsingError(
+            analyticsService.track(
+                AnalyticsEvent.Error.EmailParsingError(
                     handlerName = newsletterHandlerName,
                     emailTitle = emailTitle,
                 )
             )
-        } catch (e: AnalyticException) {
+        } catch (e: AnalyticsException) {
             LOG.error("Could not track EmailParsingError event", e)
         }
     }

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspect.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspect.kt
@@ -51,11 +51,37 @@ class AnalyticsAspect(
     }
 
     @AfterThrowing("homePointcut()", throwing = "error")
-    fun homeError(joinPoint: JoinPoint, error: Exception) {
+    fun trackHomeError(joinPoint: JoinPoint, error: Exception) {
         try {
             analyticsService.track(AnalyticsEvent.Error.HomeError)
         } catch (e: AnalyticsException) {
             LOG.error("Could not track HomeError event", e)
+        }
+    }
+    //endregion
+
+    //region GetRssFeeds
+    @Pointcut(
+        "@annotation(org.springframework.web.bind.annotation.GetMapping)" +
+            "&& execution(* getRssFeeds(..))"
+    )
+    fun getRssFeedsPointcut() = Unit
+
+    @Before("getRssFeedsPointcut()")
+    fun trackGetRssFeeds(joinPoint: JoinPoint) {
+        try {
+            analyticsService.track(AnalyticsEvent.GetRssFeeds)
+        } catch (e: AnalyticsException) {
+            LOG.error("Could not track GetRssFeeds event", e)
+        }
+    }
+
+    @AfterThrowing("getRssFeedsPointcut()", throwing = "error")
+    fun trackGetRssFeedsError(joinPoint: JoinPoint, error: Exception) {
+        try {
+            analyticsService.track(AnalyticsEvent.Error.GetRssFeedsError)
+        } catch (e: AnalyticsException) {
+            LOG.error("Could not track GetRssFeedsError event", e)
         }
     }
     //endregion
@@ -84,7 +110,7 @@ class AnalyticsAspect(
     }
 
     @AfterThrowing("getFeedPointcut()", throwing = "error")
-    fun getFeedError(joinPoint: JoinPoint, error: Exception) {
+    fun trackGetFeedError(joinPoint: JoinPoint, error: Exception) {
         try {
             val code = extractCode(joinPoint.args)
             analyticsService.track(AnalyticsEvent.Error.GetFeedError(code))
@@ -124,7 +150,7 @@ class AnalyticsAspect(
     }
 
     @AfterThrowing("requestNewsletterPointcut()", throwing = "error")
-    fun requestNewsletterError(joinPoint: JoinPoint, error: Exception) {
+    fun trackRequestNewsletterError(joinPoint: JoinPoint, error: Exception) {
         try {
             analyticsService.track(AnalyticsEvent.Error.RequestNewsletterError)
         } catch (e: AnalyticsException) {
@@ -138,7 +164,7 @@ class AnalyticsAspect(
     fun newsletterHandlerProcessPointcut() = Unit
 
     @AfterThrowing("newsletterHandlerProcessPointcut()", throwing = "error")
-    fun newsletterHandlerProcessError(joinPoint: JoinPoint, error: Exception) {
+    fun trackNewsletterHandlerProcessError(joinPoint: JoinPoint, error: Exception) {
         try {
             val email = joinPoint.args[0] as Email
             val newsletterHandlerName = (joinPoint.target).javaClass.simpleName

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspect.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspect.kt
@@ -19,6 +19,7 @@ package fr.nicopico.n2rss.analytics
 
 import fr.nicopico.n2rss.models.Email
 import fr.nicopico.n2rss.utils.getCallArgument
+import fr.nicopico.n2rss.utils.getFingerprint
 import fr.nicopico.n2rss.utils.proceed
 import org.aspectj.lang.JoinPoint
 import org.aspectj.lang.ProceedingJoinPoint
@@ -39,7 +40,8 @@ class AnalyticsAspect(
 ) {
     private fun JoinPoint.getUserAgent(): String {
         val userAgent = getCallArgument<String>("userAgent")
-        return userAgent
+        return getFingerprint(userAgent)
+            ?: "[[UNKNOWN UA]]"
     }
 
     //region Home

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspect.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspect.kt
@@ -33,6 +33,7 @@ private val LOG = LoggerFactory.getLogger(AnalyticsAspect::class.java)
 
 @Aspect
 @Component
+@Suppress("UnusedParameter", "TooManyFunctions")
 class AnalyticsAspect(
     private val analyticsService: AnalyticsService
 ) {
@@ -189,7 +190,10 @@ class AnalyticsAspect(
     //endregion
 
     //region Parsing
-    @Pointcut("execution(* fr.nicopico.n2rss.mail.newsletter.NewsletterHandler+.process(fr.nicopico.n2rss.models.Email))")
+    @Pointcut(
+        "execution(* fr.nicopico.n2rss.mail.newsletter.NewsletterHandler+" +
+            ".process(fr.nicopico.n2rss.models.Email))"
+    )
     fun newsletterHandlerProcessPointcut() = Unit
 
     @AfterThrowing("newsletterHandlerProcessPointcut()", throwing = "error")

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsEvent.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsEvent.kt
@@ -15,7 +15,39 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
 package fr.nicopico.n2rss.analytics
 
-class AnalyticException(message: String?, cause: Throwable?) : Exception(message, cause)
+sealed class AnalyticsEvent {
+    /**
+     * A user accessed the home page
+     */
+    data object Home : AnalyticsEvent()
+
+    /**
+     * A user accessed an RSS feed
+     */
+    data class GetFeed(
+        val feedCode: String,
+        val userAgent: String?,
+    ) : AnalyticsEvent()
+
+    /**
+     * A user requested support for a newsletter
+     */
+    data class RequestNewsletter(val newsletterUrl: String) : AnalyticsEvent()
+
+    sealed class Error : AnalyticsEvent() {
+        data object HomeError : Error()
+        data class GetFeedError(val feedCode: String) : Error()
+        data object RequestNewsletterError : Error()
+        data class EmailParsingError(
+            val handlerName: String,
+            val emailTitle: String
+        ) : Error()
+    }
+
+    /**
+     * A new version has been released to production
+     */
+    data class NewRelease(val version: String) : AnalyticsEvent()
+}

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsEvent.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsEvent.kt
@@ -24,6 +24,11 @@ sealed class AnalyticsEvent {
     data object Home : AnalyticsEvent()
 
     /**
+     * A user accessed the JSON list of RSS feeds
+     */
+    data object GetRssFeeds : AnalyticsEvent()
+
+    /**
      * A user accessed an RSS feed
      */
     data class GetFeed(
@@ -38,6 +43,7 @@ sealed class AnalyticsEvent {
 
     sealed class Error : AnalyticsEvent() {
         data object HomeError : Error()
+        data object GetRssFeedsError : Error()
         data class GetFeedError(val feedCode: String) : Error()
         data object RequestNewsletterError : Error()
         data class EmailParsingError(

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsEvent.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsEvent.kt
@@ -21,25 +21,32 @@ sealed class AnalyticsEvent {
     /**
      * A user accessed the home page
      */
-    data object Home : AnalyticsEvent()
+    data class Home(
+        val userAgent: String,
+    ) : AnalyticsEvent()
 
     /**
      * A user accessed the JSON list of RSS feeds
      */
-    data object GetRssFeeds : AnalyticsEvent()
+    data class GetRssFeeds(
+        val userAgent: String,
+    ) : AnalyticsEvent()
 
     /**
      * A user accessed an RSS feed
      */
     data class GetFeed(
         val feedCode: String,
-        val userAgent: String?,
+        val userAgent: String,
     ) : AnalyticsEvent()
 
     /**
      * A user requested support for a newsletter
      */
-    data class RequestNewsletter(val newsletterUrl: String) : AnalyticsEvent()
+    data class RequestNewsletter(
+        val newsletterUrl: String,
+        val userAgent: String,
+    ) : AnalyticsEvent()
 
     sealed class Error : AnalyticsEvent() {
         data object HomeError : Error()

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsException.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsException.kt
@@ -18,4 +18,7 @@
 
 package fr.nicopico.n2rss.analytics
 
-class AnalyticsException(message: String?, cause: Throwable?) : Exception(message, cause)
+class AnalyticsException(
+    message: String? = null,
+    cause: Throwable? = null
+) : Exception(message, cause)

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsException.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsException.kt
@@ -15,39 +15,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
+
 package fr.nicopico.n2rss.analytics
 
-sealed class AnalyticEvent {
-    /**
-     * A user accessed the home page
-     */
-    data object Home : AnalyticEvent()
-
-    /**
-     * A user accessed an RSS feed
-     */
-    data class GetFeed(
-        val feedCode: String,
-        val userAgent: String?,
-    ) : AnalyticEvent()
-
-    /**
-     * A user requested support for a newsletter
-     */
-    data class RequestNewsletter(val newsletterUrl: String) : AnalyticEvent()
-
-    sealed class Error : AnalyticEvent() {
-        data object HomeError : Error()
-        data class GetFeedError(val feedCode: String) : Error()
-        data object RequestNewsletterError : Error()
-        data class EmailParsingError(
-            val handlerName: String,
-            val emailTitle: String
-        ) : Error()
-    }
-
-    /**
-     * A new version has been released to production
-     */
-    data class NewRelease(val version: String) : AnalyticEvent()
-}
+class AnalyticsException(message: String?, cause: Throwable?) : Exception(message, cause)

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsService.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsService.kt
@@ -25,10 +25,10 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
-private val LOG = LoggerFactory.getLogger(AnalyticService::class.java)
+private val LOG = LoggerFactory.getLogger(AnalyticsService::class.java)
 
 @Service
-class AnalyticService(
+class AnalyticsService(
     private val analyticsRepository: AnalyticsRepository,
     private val analyticsProperties: N2RssProperties.AnalyticsProperties,
     private val clock: Clock,
@@ -39,15 +39,15 @@ class AnalyticService(
         analyticsProperties: N2RssProperties.AnalyticsProperties,
     ) : this(analyticsRepository, analyticsProperties, Clock.System)
 
-    @Throws(AnalyticException::class)
-    fun track(event: AnalyticEvent) {
+    @Throws(AnalyticsException::class)
+    fun track(event: AnalyticsEvent) {
         if (analyticsProperties.enabled) {
             LOG.info("TRACK: $event")
             try {
                 val data = event.toAnalyticsData(clock.now())
                 analyticsRepository.save(data)
             } catch (e: Exception) {
-                throw AnalyticException("Unable to send analytics event $event", e)
+                throw AnalyticsException("Unable to send analytics event $event", e)
             }
         }
     }

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsService.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/AnalyticsService.kt
@@ -43,6 +43,8 @@ class AnalyticsService(
     fun track(event: AnalyticsEvent) {
         if (analyticsProperties.enabled) {
             LOG.info("TRACK: $event")
+            // We want to catch all possible issues here
+            @Suppress("TooGenericExceptionCaught")
             try {
                 val data = event.toAnalyticsData(clock.now())
                 analyticsRepository.save(data)

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
@@ -60,6 +60,7 @@ object AnalyticsDataCode {
     const val DATA_EMAIL_TITLE = "emailTitle"
 }
 
+@Suppress("LongMethod")
 fun AnalyticsEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
     return when (this) {
         is AnalyticsEvent.GetFeed -> AnalyticsData(
@@ -73,17 +74,26 @@ fun AnalyticsEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
 
         is AnalyticsEvent.GetRssFeeds -> AnalyticsData(
             code = AnalyticsDataCode.GET_RSS_FEEDS,
+            data = mapOf(
+                DATA_USER_AGENT to userAgent,
+            ),
             timestamp = timestamp,
         )
 
         is AnalyticsEvent.Home -> AnalyticsData(
             code = AnalyticsDataCode.HOME,
+            data = mapOf(
+                DATA_USER_AGENT to userAgent,
+            ),
             timestamp = timestamp,
         )
 
         is AnalyticsEvent.RequestNewsletter -> AnalyticsData(
             code = AnalyticsDataCode.REQUEST_NEWSLETTER,
-            data = mapOf(DATA_NEWSLETTER_URL to newsletterUrl),
+            data = mapOf(
+                DATA_NEWSLETTER_URL to newsletterUrl,
+                DATA_USER_AGENT to userAgent,
+            ),
             timestamp = timestamp,
         )
 
@@ -122,7 +132,5 @@ fun AnalyticsEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
             code = AnalyticsDataCode.ERROR_REQUEST_NEWSLETTER,
             timestamp = timestamp,
         )
-
-
     }
 }

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
@@ -46,7 +46,7 @@ fun AnalyticEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
     return when (this) {
         is AnalyticEvent.GetFeed -> AnalyticsData(
             code = AnalyticsDataCode.GET_FEED,
-            data = feedCode,
+            data = "$feedCode;;$userAgent",
             timestamp = timestamp,
         )
 

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
@@ -110,5 +110,9 @@ fun AnalyticsEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
             code = AnalyticsDataCode.ERROR_REQUEST_NEWSLETTER,
             timestamp = timestamp,
         )
+
+        AnalyticsEvent.Error.GetRssFeedsError -> TODO()
+
+        AnalyticsEvent.GetRssFeeds -> TODO()
     }
 }

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
@@ -17,7 +17,7 @@
  */
 package fr.nicopico.n2rss.analytics.data
 
-import fr.nicopico.n2rss.analytics.AnalyticEvent
+import fr.nicopico.n2rss.analytics.AnalyticsEvent
 import fr.nicopico.n2rss.analytics.data.AnalyticsDataCode.DATA_EMAIL_TITLE
 import fr.nicopico.n2rss.analytics.data.AnalyticsDataCode.DATA_FEED_CODE
 import fr.nicopico.n2rss.analytics.data.AnalyticsDataCode.DATA_HANDLER_NAME
@@ -58,9 +58,9 @@ object AnalyticsDataCode {
     const val DATA_EMAIL_TITLE = "emailTitle"
 }
 
-fun AnalyticEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
+fun AnalyticsEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
     return when (this) {
-        is AnalyticEvent.GetFeed -> AnalyticsData(
+        is AnalyticsEvent.GetFeed -> AnalyticsData(
             code = GET_FEED,
             data = mapOf(
                 DATA_FEED_CODE to feedCode,
@@ -69,30 +69,30 @@ fun AnalyticEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
             timestamp = timestamp,
         )
 
-        is AnalyticEvent.Home -> AnalyticsData(
+        is AnalyticsEvent.Home -> AnalyticsData(
             code = AnalyticsDataCode.HOME,
             timestamp = timestamp,
         )
 
-        is AnalyticEvent.RequestNewsletter -> AnalyticsData(
+        is AnalyticsEvent.RequestNewsletter -> AnalyticsData(
             code = AnalyticsDataCode.REQUEST_NEWSLETTER,
             data = mapOf(DATA_NEWSLETTER_URL to newsletterUrl),
             timestamp = timestamp,
         )
 
-        is AnalyticEvent.NewRelease -> AnalyticsData(
+        is AnalyticsEvent.NewRelease -> AnalyticsData(
             code = AnalyticsDataCode.RELEASE,
             data = mapOf(DATA_VERSION to version),
             timestamp = timestamp,
         )
 
-        is AnalyticEvent.Error.GetFeedError -> AnalyticsData(
+        is AnalyticsEvent.Error.GetFeedError -> AnalyticsData(
             code = AnalyticsDataCode.ERROR_GET_FEED,
             data = mapOf(DATA_FEED_CODE to feedCode),
             timestamp = timestamp,
         )
 
-        is AnalyticEvent.Error.EmailParsingError -> AnalyticsData(
+        is AnalyticsEvent.Error.EmailParsingError -> AnalyticsData(
             code = AnalyticsDataCode.ERROR_PARSING,
             data = mapOf(
                 DATA_HANDLER_NAME to handlerName,
@@ -101,12 +101,12 @@ fun AnalyticEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
             timestamp = timestamp,
         )
 
-        is AnalyticEvent.Error.HomeError -> AnalyticsData(
+        is AnalyticsEvent.Error.HomeError -> AnalyticsData(
             code = AnalyticsDataCode.ERROR_HOME,
             timestamp = timestamp,
         )
 
-        is AnalyticEvent.Error.RequestNewsletterError -> AnalyticsData(
+        is AnalyticsEvent.Error.RequestNewsletterError -> AnalyticsData(
             code = AnalyticsDataCode.ERROR_REQUEST_NEWSLETTER,
             timestamp = timestamp,
         )

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Nicolas PICON
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package fr.nicopico.n2rss.analytics.data
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+
+@Document(collection = "analytics")
+class AnalyticsData(
+    val code: String,
+    val data: String? = null,
+    @Id val id: String? = null,
+)
+
+object AnalyticsDataCode {
+    const val HOME = "home"
+    const val GET_FEED = "get-feed"
+    const val REQUEST_NEWSLETTER = "request-newsletter"
+}

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
@@ -17,10 +17,12 @@
  */
 package fr.nicopico.n2rss.analytics.data
 
+import fr.nicopico.n2rss.analytics.AnalyticEvent
 import kotlinx.datetime.Instant
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 
+@Suppress("unused")
 @Document(collection = "analytics")
 class AnalyticsData(
     val code: String,
@@ -29,8 +31,62 @@ class AnalyticsData(
     @Id val id: String? = null,
 )
 
-object AnalyticsDataCode {
+private object AnalyticsDataCode {
     const val HOME = "home"
     const val GET_FEED = "get-feed"
     const val REQUEST_NEWSLETTER = "request-newsletter"
+    const val RELEASE = "release"
+    const val ERROR_GET_FEED = "error-get-feed"
+    const val ERROR_PARSING = "error-parsing"
+    const val ERROR_HOME = "error-home"
+    const val ERROR_REQUEST_NEWSLETTER = "error-request-newsletter"
+}
+
+fun AnalyticEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
+    return when (this) {
+        is AnalyticEvent.GetFeed -> AnalyticsData(
+            code = AnalyticsDataCode.GET_FEED,
+            data = feedCode,
+            timestamp = timestamp,
+        )
+
+        is AnalyticEvent.Home -> AnalyticsData(
+            code = AnalyticsDataCode.HOME,
+            timestamp = timestamp,
+        )
+
+        is AnalyticEvent.RequestNewsletter -> AnalyticsData(
+            code = AnalyticsDataCode.REQUEST_NEWSLETTER,
+            data = newsletterUrl,
+            timestamp = timestamp,
+        )
+
+        is AnalyticEvent.Release -> AnalyticsData(
+            code = AnalyticsDataCode.RELEASE,
+            data = version,
+            timestamp = timestamp,
+        )
+
+        is AnalyticEvent.Error.GetFeedError -> AnalyticsData(
+            code = AnalyticsDataCode.ERROR_GET_FEED,
+            data = feedCode,
+            timestamp = timestamp,
+        )
+
+        is AnalyticEvent.Error.EmailParsingError -> AnalyticsData(
+            code = AnalyticsDataCode.ERROR_PARSING,
+            data = "${handlerName};;$emailTitle",
+            timestamp = timestamp,
+        )
+
+        is AnalyticEvent.Error.HomeError -> AnalyticsData(
+            code = AnalyticsDataCode.ERROR_HOME,
+            timestamp = timestamp,
+        )
+
+        is AnalyticEvent.Error.RequestNewsletterError -> AnalyticsData(
+            code = AnalyticsDataCode.ERROR_REQUEST_NEWSLETTER,
+            timestamp = timestamp,
+        )
+    }
 }

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
@@ -32,7 +32,7 @@ import org.springframework.data.mongodb.core.mapping.Document
 
 @Suppress("unused")
 @Document(collection = "analytics")
-class AnalyticsData(
+data class AnalyticsData(
     val code: String,
     val timestamp: Instant,
     val data: Map<String, String?> = emptyMap(),
@@ -50,12 +50,12 @@ object AnalyticsDataCode {
     const val ERROR_HOME = "error-home"
     const val ERROR_REQUEST_NEWSLETTER = "error-request-newsletter"
 
-    const val DATA_FEED_CODE = "data-feed-code"
-    const val DATA_USER_AGENT = "data-user-agent"
-    const val DATA_NEWSLETTER_URL = "data-newsletter-url"
-    const val DATA_VERSION = "data-version"
-    const val DATA_HANDLER_NAME = "data-handler-name"
-    const val DATA_EMAIL_TITLE = "data-email-title"
+    const val DATA_FEED_CODE = "feedCode"
+    const val DATA_USER_AGENT = "userAgent"
+    const val DATA_NEWSLETTER_URL = "newsletterUrl"
+    const val DATA_VERSION = "version"
+    const val DATA_HANDLER_NAME = "handlerName"
+    const val DATA_EMAIL_TITLE = "emailTitle"
 }
 
 fun AnalyticEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
@@ -61,7 +61,7 @@ fun AnalyticEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
             timestamp = timestamp,
         )
 
-        is AnalyticEvent.Release -> AnalyticsData(
+        is AnalyticEvent.NewRelease -> AnalyticsData(
             code = AnalyticsDataCode.RELEASE,
             data = version,
             timestamp = timestamp,

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
@@ -18,6 +18,13 @@
 package fr.nicopico.n2rss.analytics.data
 
 import fr.nicopico.n2rss.analytics.AnalyticEvent
+import fr.nicopico.n2rss.analytics.data.AnalyticsDataCode.DATA_EMAIL_TITLE
+import fr.nicopico.n2rss.analytics.data.AnalyticsDataCode.DATA_FEED_CODE
+import fr.nicopico.n2rss.analytics.data.AnalyticsDataCode.DATA_HANDLER_NAME
+import fr.nicopico.n2rss.analytics.data.AnalyticsDataCode.DATA_NEWSLETTER_URL
+import fr.nicopico.n2rss.analytics.data.AnalyticsDataCode.DATA_USER_AGENT
+import fr.nicopico.n2rss.analytics.data.AnalyticsDataCode.DATA_VERSION
+import fr.nicopico.n2rss.analytics.data.AnalyticsDataCode.GET_FEED
 import kotlinx.datetime.Instant
 import org.jetbrains.annotations.VisibleForTesting
 import org.springframework.data.annotation.Id
@@ -28,7 +35,7 @@ import org.springframework.data.mongodb.core.mapping.Document
 class AnalyticsData(
     val code: String,
     val timestamp: Instant,
-    val data: String? = null,
+    val data: Map<String, String?> = emptyMap(),
     @Id val id: String? = null,
 )
 
@@ -42,13 +49,23 @@ object AnalyticsDataCode {
     const val ERROR_PARSING = "error-parsing"
     const val ERROR_HOME = "error-home"
     const val ERROR_REQUEST_NEWSLETTER = "error-request-newsletter"
+
+    const val DATA_FEED_CODE = "data-feed-code"
+    const val DATA_USER_AGENT = "data-user-agent"
+    const val DATA_NEWSLETTER_URL = "data-newsletter-url"
+    const val DATA_VERSION = "data-version"
+    const val DATA_HANDLER_NAME = "data-handler-name"
+    const val DATA_EMAIL_TITLE = "data-email-title"
 }
 
 fun AnalyticEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
     return when (this) {
         is AnalyticEvent.GetFeed -> AnalyticsData(
-            code = AnalyticsDataCode.GET_FEED,
-            data = "$feedCode;;$userAgent",
+            code = GET_FEED,
+            data = mapOf(
+                DATA_FEED_CODE to feedCode,
+                DATA_USER_AGENT to userAgent,
+            ),
             timestamp = timestamp,
         )
 
@@ -59,25 +76,28 @@ fun AnalyticEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
 
         is AnalyticEvent.RequestNewsletter -> AnalyticsData(
             code = AnalyticsDataCode.REQUEST_NEWSLETTER,
-            data = newsletterUrl,
+            data = mapOf(DATA_NEWSLETTER_URL to newsletterUrl),
             timestamp = timestamp,
         )
 
         is AnalyticEvent.NewRelease -> AnalyticsData(
             code = AnalyticsDataCode.RELEASE,
-            data = version,
+            data = mapOf(DATA_VERSION to version),
             timestamp = timestamp,
         )
 
         is AnalyticEvent.Error.GetFeedError -> AnalyticsData(
             code = AnalyticsDataCode.ERROR_GET_FEED,
-            data = feedCode,
+            data = mapOf(DATA_FEED_CODE to feedCode),
             timestamp = timestamp,
         )
 
         is AnalyticEvent.Error.EmailParsingError -> AnalyticsData(
             code = AnalyticsDataCode.ERROR_PARSING,
-            data = "${handlerName};;$emailTitle",
+            data = mapOf(
+                DATA_HANDLER_NAME to handlerName,
+                DATA_EMAIL_TITLE to emailTitle,
+            ),
             timestamp = timestamp,
         )
 

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
@@ -43,9 +43,11 @@ data class AnalyticsData(
 object AnalyticsDataCode {
     const val HOME = "home"
     const val GET_FEED = "get-feed"
+    const val GET_RSS_FEEDS = "get-rss-feeds"
     const val REQUEST_NEWSLETTER = "request-newsletter"
     const val RELEASE = "release"
     const val ERROR_GET_FEED = "error-get-feed"
+    const val ERROR_GET_RSS_FEEDS = "error-get-rss-feeds"
     const val ERROR_PARSING = "error-parsing"
     const val ERROR_HOME = "error-home"
     const val ERROR_REQUEST_NEWSLETTER = "error-request-newsletter"
@@ -66,6 +68,11 @@ fun AnalyticsEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
                 DATA_FEED_CODE to feedCode,
                 DATA_USER_AGENT to userAgent,
             ),
+            timestamp = timestamp,
+        )
+
+        is AnalyticsEvent.GetRssFeeds -> AnalyticsData(
+            code = AnalyticsDataCode.GET_RSS_FEEDS,
             timestamp = timestamp,
         )
 
@@ -92,6 +99,11 @@ fun AnalyticsEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
             timestamp = timestamp,
         )
 
+        AnalyticsEvent.Error.GetRssFeedsError -> AnalyticsData(
+            code = AnalyticsDataCode.ERROR_GET_RSS_FEEDS,
+            timestamp = timestamp,
+        )
+
         is AnalyticsEvent.Error.EmailParsingError -> AnalyticsData(
             code = AnalyticsDataCode.ERROR_PARSING,
             data = mapOf(
@@ -111,8 +123,6 @@ fun AnalyticsEvent.toAnalyticsData(timestamp: Instant): AnalyticsData {
             timestamp = timestamp,
         )
 
-        AnalyticsEvent.Error.GetRssFeedsError -> TODO()
 
-        AnalyticsEvent.GetRssFeeds -> TODO()
     }
 }

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
@@ -19,6 +19,7 @@ package fr.nicopico.n2rss.analytics.data
 
 import fr.nicopico.n2rss.analytics.AnalyticEvent
 import kotlinx.datetime.Instant
+import org.jetbrains.annotations.VisibleForTesting
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 
@@ -31,7 +32,8 @@ class AnalyticsData(
     @Id val id: String? = null,
 )
 
-private object AnalyticsDataCode {
+@VisibleForTesting
+object AnalyticsDataCode {
     const val HOME = "home"
     const val GET_FEED = "get-feed"
     const val REQUEST_NEWSLETTER = "request-newsletter"

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsData.kt
@@ -17,12 +17,14 @@
  */
 package fr.nicopico.n2rss.analytics.data
 
+import kotlinx.datetime.Instant
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 
 @Document(collection = "analytics")
 class AnalyticsData(
     val code: String,
+    val timestamp: Instant,
     val data: String? = null,
     @Id val id: String? = null,
 )

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsRepository.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsRepository.kt
@@ -19,5 +19,4 @@ package fr.nicopico.n2rss.analytics.data
 
 import org.springframework.data.mongodb.repository.MongoRepository
 
-interface AnalyticsRepository : MongoRepository<AnalyticsData, String> {
-}
+interface AnalyticsRepository : MongoRepository<AnalyticsData, String>

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsRepository.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/data/AnalyticsRepository.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 Nicolas PICON
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package fr.nicopico.n2rss.analytics.data
+
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface AnalyticsRepository : MongoRepository<AnalyticsData, String> {
+}

--- a/src/main/kotlin/fr/nicopico/n2rss/config/N2RssConfiguration.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/config/N2RssConfiguration.kt
@@ -86,7 +86,5 @@ constructor(
     )
     data class AnalyticsProperties(
         val enabled: Boolean = true,
-        val userAgent: String,
-        val hostname: String,
     )
 }

--- a/src/main/kotlin/fr/nicopico/n2rss/controller/home/HomeController.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/controller/home/HomeController.kt
@@ -34,6 +34,7 @@ import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import java.net.URL
@@ -48,7 +49,12 @@ class HomeController(
 ) {
 
     @GetMapping("/")
-    fun home(request: HttpServletRequest, model: Model): String {
+    fun home(
+        request: HttpServletRequest,
+        model: Model,
+        @Suppress("UnusedParameter") /* Used by AnalyticsAspect */
+        @RequestHeader(value = "User-Agent") userAgent: String,
+    ): String {
         val groupedNewsletterInfos: List<GroupedNewsletterInfo> = newsletterService.getNewslettersInfo()
             .sortedBy { it.title }
             .filter { it.publicationCount > 0 }
@@ -80,6 +86,8 @@ class HomeController(
     fun requestNewsletter(
         @NotEmpty @Url @RequestParam("newsletterUrl") newsletterUrl: String,
         @RequestParam("g-recaptcha-response") captchaResponse: String? = null,
+        @Suppress("UnusedParameter") /* Used by AnalyticsAspect */
+        @RequestHeader(value = "User-Agent") userAgent: String,
     ): ResponseEntity<String> {
         val isCaptchaValid = if (recaptchaProperties.enabled) {
             reCaptchaService.isCaptchaValid(

--- a/src/main/kotlin/fr/nicopico/n2rss/controller/home/HomeController.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/controller/home/HomeController.kt
@@ -109,6 +109,9 @@ class HomeController(
         }
     }
 
+    @GetMapping("/privacy-policy")
+    fun privacyPolicy(): String = "privacy"
+
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(ConstraintViolationException::class)
     fun handleExceptions(

--- a/src/main/kotlin/fr/nicopico/n2rss/controller/maintenance/MaintenanceController.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/controller/maintenance/MaintenanceController.kt
@@ -17,8 +17,8 @@
  */
 package fr.nicopico.n2rss.controller.maintenance
 
-import fr.nicopico.n2rss.analytics.AnalyticEvent
-import fr.nicopico.n2rss.analytics.AnalyticService
+import fr.nicopico.n2rss.analytics.AnalyticsEvent
+import fr.nicopico.n2rss.analytics.AnalyticsService
 import fr.nicopico.n2rss.config.N2RssProperties
 import jakarta.servlet.http.HttpServletResponse
 import org.jetbrains.annotations.VisibleForTesting
@@ -35,7 +35,7 @@ import kotlin.concurrent.thread
 @Controller
 class MaintenanceController(
     private val applicationContext: ApplicationContext,
-    private val analyticService: AnalyticService,
+    private val analyticsService: AnalyticsService,
     private val properties: N2RssProperties.MaintenanceProperties,
 ) {
     @PostMapping("/notifyRelease")
@@ -49,7 +49,7 @@ class MaintenanceController(
             return
         }
 
-        analyticService.track(AnalyticEvent.NewRelease(version))
+        analyticsService.track(AnalyticsEvent.NewRelease(version))
     }
 
     @PostMapping("/stop", produces = [MediaType.TEXT_PLAIN_VALUE])

--- a/src/main/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedController.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedController.kt
@@ -23,6 +23,7 @@ import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -48,15 +49,13 @@ class RssFeedController(
      * @param publicationCount The maximum number of publications to retrieve. Default is 2.
      * @param response The HttpServletResponse object used for writing the feed to the response output stream.
      */
-    @GetMapping(
-        "{feed}",
-        produces = [RSS_CONTENT_TYPE],
-    )
+    @GetMapping("{feed}", produces = [RSS_CONTENT_TYPE])
     fun getFeed(
         @PathVariable("feed") code: String,
         @RequestParam(value = "publicationStart", defaultValue = "0") publicationStart: Int,
         @RequestParam(value = "publicationCount", defaultValue = "2") publicationCount: Int,
         response: HttpServletResponse,
+        @RequestHeader(value = "User-Agent") userAgent: String,
     ) {
         writeFeedToResponse(code, publicationStart, publicationCount, response)
     }
@@ -70,16 +69,14 @@ class RssFeedController(
      * @param publicationCount The maximum number of publications to retrieve. Default is 2.
      * @param response The HttpServletResponse object used for writing the feed to the response output stream.
      */
-    @GetMapping(
-        "{folder}/{feed}",
-        produces = [RSS_CONTENT_TYPE],
-    )
+    @GetMapping("{folder}/{feed}", produces = [RSS_CONTENT_TYPE])
     fun getFeed(
         @PathVariable("folder") folder: String,
         @PathVariable("feed") feed: String,
         @RequestParam(value = "publicationStart", defaultValue = "0") publicationStart: Int,
         @RequestParam(value = "publicationCount", defaultValue = "2") publicationCount: Int,
         response: HttpServletResponse,
+        @RequestHeader(value = "User-Agent") userAgent: String,
     ) {
         val code = "$folder/$feed"
         writeFeedToResponse(code, publicationStart, publicationCount, response)

--- a/src/main/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedController.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedController.kt
@@ -54,8 +54,9 @@ class RssFeedController(
         @PathVariable("feed") code: String,
         @RequestParam(value = "publicationStart", defaultValue = "0") publicationStart: Int,
         @RequestParam(value = "publicationCount", defaultValue = "2") publicationCount: Int,
-        response: HttpServletResponse,
+        @Suppress("UnusedParameter") /* Used by AnalyticsAspect */
         @RequestHeader(value = "User-Agent") userAgent: String,
+        response: HttpServletResponse,
     ) {
         writeFeedToResponse(code, publicationStart, publicationCount, response)
     }
@@ -70,13 +71,15 @@ class RssFeedController(
      * @param response The HttpServletResponse object used for writing the feed to the response output stream.
      */
     @GetMapping("{folder}/{feed}", produces = [RSS_CONTENT_TYPE])
+    @Suppress("LongParameterList")
     fun getFeed(
         @PathVariable("folder") folder: String,
         @PathVariable("feed") feed: String,
         @RequestParam(value = "publicationStart", defaultValue = "0") publicationStart: Int,
         @RequestParam(value = "publicationCount", defaultValue = "2") publicationCount: Int,
-        response: HttpServletResponse,
+        @Suppress("UnusedParameter") /* Used by AnalyticsAspect */
         @RequestHeader(value = "User-Agent") userAgent: String,
+        response: HttpServletResponse,
     ) {
         val code = "$folder/$feed"
         writeFeedToResponse(code, publicationStart, publicationCount, response)

--- a/src/main/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedController.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedController.kt
@@ -36,7 +36,10 @@ class RssFeedController(
     private val rssOutputWriter: RssOutputWriter,
 ) {
     @GetMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun getRssFeeds(): List<NewsletterDTO> {
+    fun getRssFeeds(
+        @Suppress("UnusedParameter") /* Used by AnalyticsAspect */
+        @RequestHeader(value = "User-Agent") userAgent: String,
+    ): List<NewsletterDTO> {
         return newsletterService.getNewslettersInfo()
             .map { it.toDTO() }
     }

--- a/src/main/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedController.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedController.kt
@@ -44,21 +44,21 @@ class RssFeedController(
     /**
      * Retrieves the RSS feed of publications.
      *
-     * @param code Code associated with the feed
+     * @param feed Code associated with the feed
      * @param publicationStart The starting index of publications to retrieve. Default is 0.
      * @param publicationCount The maximum number of publications to retrieve. Default is 2.
      * @param response The HttpServletResponse object used for writing the feed to the response output stream.
      */
     @GetMapping("{feed}", produces = [RSS_CONTENT_TYPE])
     fun getFeed(
-        @PathVariable("feed") code: String,
+        @PathVariable("feed") feed: String,
         @RequestParam(value = "publicationStart", defaultValue = "0") publicationStart: Int,
         @RequestParam(value = "publicationCount", defaultValue = "2") publicationCount: Int,
         @Suppress("UnusedParameter") /* Used by AnalyticsAspect */
         @RequestHeader(value = "User-Agent") userAgent: String,
         response: HttpServletResponse,
     ) {
-        writeFeedToResponse(code, publicationStart, publicationCount, response)
+        writeFeedToResponse(feed, publicationStart, publicationCount, response)
     }
 
     /**

--- a/src/main/kotlin/fr/nicopico/n2rss/data/CleanLocalDatabase.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/data/CleanLocalDatabase.kt
@@ -17,6 +17,7 @@
  */
 package fr.nicopico.n2rss.data
 
+import fr.nicopico.n2rss.analytics.data.AnalyticsRepository
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.context.event.ContextRefreshedEvent
@@ -29,10 +30,14 @@ private val LOG = LoggerFactory.getLogger(CleanLocalDatabase::class.java)
 @Component
 class CleanLocalDatabase(
     private val publicationRepository: PublicationRepository,
+    private val newsletterRequestRepository: NewsletterRequestRepository,
+    private val analyticsRepository: AnalyticsRepository,
 ) {
     @EventListener
     fun onApplicationEvent(ignored: ContextRefreshedEvent) {
         LOG.info("Clean-up local database...")
         publicationRepository.deleteAll()
+        newsletterRequestRepository.deleteAll()
+        analyticsRepository.deleteAll()
     }
 }

--- a/src/main/kotlin/fr/nicopico/n2rss/models/GroupedNewsletterInfo.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/models/GroupedNewsletterInfo.kt
@@ -15,7 +15,6 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
 package fr.nicopico.n2rss.models
 
 data class GroupedNewsletterInfo(

--- a/src/main/kotlin/fr/nicopico/n2rss/models/Sender.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/models/Sender.kt
@@ -15,14 +15,21 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
+
 package fr.nicopico.n2rss.models
 
-import kotlinx.datetime.LocalDate
-
-data class Email(
-    val sender: Sender,
-    val date: LocalDate,
-    val subject: String,
-    val content: String,
-    val msgnum: Int,
-)
+/**
+ * Email sender in the format "Newsletter Name <email@domain.com>"
+ */
+@JvmInline
+value class Sender(val sender: String) {
+    val email: String
+        get() = sender
+            .dropWhile { it != '<' }
+            .drop(1)
+            .dropLast(1)
+    val name: String
+        get() = sender
+            .takeWhile { it != '<' }
+            .trim()
+}

--- a/src/main/kotlin/fr/nicopico/n2rss/utils/AspectUtils.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/utils/AspectUtils.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Nicolas PICON
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package fr.nicopico.n2rss.utils
+
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+
+/**
+ * Call this function on the [ProceedingJoinPoint] retrieved from
+ * an [Around] advice.
+ * @param trackSuccess will be called in case the function was successful
+ * @param trackError will be called in case the function failed
+ */
+fun ProceedingJoinPoint.proceed(
+    trackSuccess: (JoinPoint) -> Unit,
+    trackError: (JoinPoint, Exception) -> Unit,
+): Any? {
+    try {
+        val result = proceed()
+        trackSuccess(this)
+        return result
+    } catch (e: Exception) {
+        trackError(this, e)
+        throw e
+    }
+}

--- a/src/main/kotlin/fr/nicopico/n2rss/utils/AspectUtils.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/utils/AspectUtils.kt
@@ -31,6 +31,8 @@ fun ProceedingJoinPoint.proceed(
     trackSuccess: (JoinPoint) -> Unit,
     trackError: (JoinPoint, Exception) -> Unit,
 ): Any? {
+    // We want to catch all possible issues here
+    @Suppress("TooGenericExceptionCaught")
     try {
         val result = proceed()
         trackSuccess(this)

--- a/src/main/kotlin/fr/nicopico/n2rss/utils/HashingUtils.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/utils/HashingUtils.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Nicolas PICON
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package fr.nicopico.n2rss.utils
+
+import org.slf4j.LoggerFactory
+import java.security.MessageDigest
+import java.security.NoSuchAlgorithmException
+
+private val LOG = LoggerFactory.getLogger("HashingUtils")
+
+/**
+ * Calculates the fingerprint of the given input using the specified algorithm.
+ *
+ * @param input the input string for which the fingerprint should be calculated
+ * @param algorithm the algorithm to use for calculating the fingerprint (default value is "SHA-256")
+ * @return the fingerprint as a hexadecimal string or null if the algorithm is not available
+ */
+fun getFingerprint(input: String, algorithm: String = "SHA-256"): String? {
+    return try {
+        val digest = input.calculateDigest(algorithm)
+        convertToHexString(digest)
+    } catch (e: NoSuchAlgorithmException) {
+        LOG.error("Could not get fingerprint from string", e)
+        null
+    }
+}
+
+private fun String.calculateDigest(algorithm: String): ByteArray {
+    val messageDigest: MessageDigest = MessageDigest.getInstance(algorithm)
+    return messageDigest.digest(this.toByteArray())
+}
+
+@Suppress("MagicNumber")
+private fun convertToHexString(digest: ByteArray): String {
+    return digest.joinToString("") {
+        val hex = Integer.toHexString(0xff and it.toInt())
+        if (hex.length == 1) "0$hex" else hex
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,7 +26,7 @@ logging.pattern.console=%d{HH:mm:ss} %5p %c{0} - %m%n
 spring.profiles.active=local
 
 # n2rss
-n2rss.analytics.enabled=false
+n2rss.analytics.enabled=true
 n2rss.email.cron=0 * * * * *
 n2rss.email.client.host=${N2RSS_EMAIL_HOST}
 n2rss.email.client.port=${N2RSS_EMAIL_PORT:993}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,8 +27,6 @@ spring.profiles.active=local
 
 # n2rss
 n2rss.analytics.enabled=false
-n2rss.analytics.hostname=
-n2rss.analytics.user-agent=
 n2rss.email.cron=0 * * * * *
 n2rss.email.client.host=${N2RSS_EMAIL_HOST}
 n2rss.email.client.port=${N2RSS_EMAIL_PORT:993}

--- a/src/main/resources/static/css/n2rss.css
+++ b/src/main/resources/static/css/n2rss.css
@@ -137,6 +137,16 @@ div.g-recaptcha {
     justify-content: center;
 }
 
+div.legalese {
+    margin: 8px auto 34px auto;
+    display: flex;
+    justify-content: center;
+}
+
+div.legalese a {
+    font-size: 0.8em;
+}
+
 .message {
     margin: 8px auto;
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -117,6 +117,10 @@
 
 </form>
 
+<div class="legalese">
+    <a th:href="@{privacy-policy}">Privacy policy</a>
+</div>
+
 <a href="https://github.com/nicopico-dev/n2rss" target="_blank">
     <img
         src="https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png?resize=149%2C149"

--- a/src/main/resources/templates/privacy.html
+++ b/src/main/resources/templates/privacy.html
@@ -1,0 +1,130 @@
+<!--
+  ~ Copyright (c) 2024 Nicolas PICON
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+  ~ documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+  ~ the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+  ~ and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all copies or substantial portions
+  ~ of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+  ~ TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  ~ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+  ~ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  ~ DEALINGS IN THE SOFTWARE.
+  -->
+<!DOCTYPE html>
+<html
+    lang="en"
+    xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>N2RSS — Privacy Policy</title>
+    <meta charset="UTF-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <link rel="stylesheet" th:href="@{/css/n2rss.css}"/>
+    <link rel="icon" th:href="@{/images/n2rss.ico}" type="image/x-icon">
+</head>
+<body>
+<div class="header">
+    <h1>Privacy Policy</h1>
+    <p><strong>Effective Date:</strong> 01/08/2024</p>
+</div>
+<div class="container">
+    <h2>Introduction</h2>
+    <p>
+        Welcome to "Newsletters to RSS" (N2RSS), an open-source project designed to provide RSS feeds for a selection of
+        newsletters.
+        We value your privacy and are committed to protecting your personal data. This Privacy Policy outlines the types
+        of information we collect, how we use it, and the measures we take to ensure your data is protected.</p>
+
+    <h2>1. Information We Collect</h2>
+    <p>When you interact with our application, we collect the following types of information:</p>
+    <ul>
+        <li>
+            <strong>Feed Access Information:</strong>
+            <ul>
+                <li><strong>Timestamp:</strong> The time when the feed is accessed.</li>
+                <li><strong>Unique ID of the Feed:</strong> An identifier associated with the specific feed being
+                    accessed.
+                </li>
+                <li><strong>User-Agent:</strong> Information about the software making the HTTP request, which is hashed
+                    to identify unique users.
+                </li>
+            </ul>
+        </li>
+        <li>
+            <strong>Newsletter Request Information:</strong>
+            <ul>
+                <li><strong>Timestamp:</strong> The time when the newsletter is requested.</li>
+                <li><strong>URL Provided by the User:</strong> The URL of the newsletter requested.</li>
+                <li><strong>User-Agent:</strong> Information about the software making the HTTP request, which is hashed
+                    to identify unique users.
+                </li>
+            </ul>
+        </li>
+        <li>
+            <strong>Error Logging Information:</strong>
+            <ul>
+                <li><strong>Timestamp of Errors:</strong> The time when an error occurs in the application.</li>
+                <li><strong>Error Details:</strong> While we do not collect detailed error information such as exception
+                    class names and stack traces, we do record the occurrence of errors for diagnostic purposes.
+                </li>
+            </ul>
+        </li>
+    </ul>
+
+    <h2>2. How We Use the Information</h2>
+    <p>The information we collect is used for the following purposes:</p>
+    <ul>
+        <li><strong>Service Improvement:</strong> To enhance the functionality and performance of N2RSS.</li>
+        <li><strong>User Experience:</strong> To ensure the service is meeting the needs of our users by identifying and
+            fixing issues.
+        </li>
+        <li><strong>Usage Statistics:</strong> To gather aggregate data on the usage patterns of the service.</li>
+    </ul>
+
+    <h2>3. Data Protection and Security</h2>
+    <p>We are committed to ensuring that your information is secure.
+        To prevent unauthorized access or disclosure, we have put in place suitable physical, electronic, and managerial
+        procedures to safeguard and secure the information we collect.</p>
+
+    <h2>4. Sharing of Information</h2>
+    <p>We do not sell, trade, or otherwise transfer your personal information to outside parties.
+        This does not include trusted third parties who assist us in operating our website or conducting our business,
+        so long as those parties agree to keep this information confidential.</p>
+
+    <h2>5. Open-Source Nature</h2>
+    <p>As N2RSS is an open-source project, its source code is publicly available on GitHub at <a
+        href="https://github.com/nicopico-dev/n2rss">https://github.com/nicopico-dev/n2rss</a>. This transparency allows
+        users to understand how their data is being handled and to contribute to improving the privacy and security
+        measures in place.</p>
+
+    <h2>6. Your Consent</h2>
+    <p>By using N2RSS, you consent to our Privacy Policy.</p>
+
+    <h2>7. Changes to Our Privacy Policy</h2>
+    <p>We may update our Privacy Policy from time to time.
+        Any changes will be posted on this page, and you are encouraged to review this policy periodically to stay
+        informed about how we are protecting the information we collect.</p>
+
+    <h2>8. Contact Us</h2>
+    <p>If you have any questions or concerns about this Privacy Policy or our data practices, please contact us at
+        <a href="mailto:n2rss-contact@nicopico.fr">n2rss-contact@nicopico.fr</a>.</p>
+
+    <h2>Conclusion</h2>
+    <p>Your privacy is important to us, and we are committed to protecting the information you share with us. Thank you
+        for using N2RSS.</p>
+</div>
+
+<!-- 100% privacy-first analytics -->
+<script async defer src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
+<noscript>
+    <img
+        alt=""
+        referrerpolicy="no-referrer-when-downgrade"
+        src="https://queue.simpleanalyticscdn.com/noscript.gif"/>
+</noscript>
+</body>
+</html>

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticServiceTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticServiceTest.kt
@@ -23,9 +23,10 @@ import fr.nicopico.n2rss.analytics.data.AnalyticsRepository
 import fr.nicopico.n2rss.config.N2RssProperties
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.maps.shouldContainAll
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
-import io.kotest.matchers.string.beEmpty
 import io.mockk.MockKAnnotations
 import io.mockk.confirmVerified
 import io.mockk.every
@@ -34,8 +35,8 @@ import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-
-private const val s = "userAgent"
+import io.kotest.matchers.maps.beEmpty as beAnEmptyMap
+import io.kotest.matchers.string.beEmpty as beAnEmptyString
 
 class AnalyticServiceTest {
 
@@ -71,7 +72,7 @@ class AnalyticServiceTest {
         verify { analyticsRepository.save(capture(dataSlot)) }
         assertSoftly(dataSlot.captured) {
             it.code shouldBe AnalyticsDataCode.HOME
-            it.data shouldBe null
+            it.data should beAnEmptyMap()
         }
     }
 
@@ -90,7 +91,10 @@ class AnalyticServiceTest {
         verify { analyticsRepository.save(capture(dataSlot)) }
         assertSoftly(dataSlot.captured) {
             it.code shouldBe AnalyticsDataCode.GET_FEED
-            it.data shouldBe rssCode
+            it.data shouldContainAll mapOf(
+                AnalyticsDataCode.DATA_FEED_CODE to rssCode,
+                AnalyticsDataCode.DATA_USER_AGENT to userAgent,
+            )
         }
     }
 
@@ -108,7 +112,9 @@ class AnalyticServiceTest {
         verify { analyticsRepository.save(capture(dataSlot)) }
         assertSoftly(dataSlot.captured) {
             it.code shouldBe AnalyticsDataCode.REQUEST_NEWSLETTER
-            it.data shouldBe newsletterUrl
+            it.data shouldContainAll mapOf(
+                AnalyticsDataCode.DATA_NEWSLETTER_URL to newsletterUrl,
+            )
         }
     }
 
@@ -123,7 +129,7 @@ class AnalyticServiceTest {
         val error = shouldThrow<AnalyticException> {
             analyticService.track(AnalyticEvent.GetFeed("code", "userAgent"))
         }
-        error.message shouldNot beEmpty()
+        error.message shouldNot beAnEmptyString()
         error.cause shouldBe internalError
     }
 

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticServiceTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticServiceTest.kt
@@ -50,15 +50,10 @@ class AnalyticServiceTest {
 
     private fun createAnalyticService(
         enabled: Boolean = true,
-        userAgent: String = "some-user-agent",
-        hostname: String = "some-hostname",
     ): AnalyticService {
         return AnalyticService(
-            analyticsApiBaseUrl = server.url("/").toString(),
             analyticsProperties = N2RssProperties.AnalyticsProperties(
                 enabled = enabled,
-                userAgent = userAgent,
-                hostname = hostname,
             ),
         )
     }

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticServiceTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticServiceTest.kt
@@ -35,6 +35,8 @@ import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+private const val s = "userAgent"
+
 class AnalyticServiceTest {
 
     @MockK
@@ -77,10 +79,11 @@ class AnalyticServiceTest {
     fun `GetFeed analytic events should be stored`() {
         // GIVEN
         val rssCode = "rss-code"
+        val userAgent = "userAgent"
         val analyticService = createAnalyticService()
 
         // WHEN
-        analyticService.track(AnalyticEvent.GetFeed(rssCode))
+        analyticService.track(AnalyticEvent.GetFeed(rssCode, userAgent))
 
         // THEN
         val dataSlot = slot<AnalyticsData>()
@@ -118,7 +121,7 @@ class AnalyticServiceTest {
 
         // WHEN - THEN
         val error = shouldThrow<AnalyticException> {
-            analyticService.track(AnalyticEvent.GetFeed("code"))
+            analyticService.track(AnalyticEvent.GetFeed("code", "userAgent"))
         }
         error.message shouldNot beEmpty()
         error.cause shouldBe internalError
@@ -131,7 +134,7 @@ class AnalyticServiceTest {
 
         // WHEN
         analyticService.track(AnalyticEvent.Home)
-        analyticService.track(AnalyticEvent.GetFeed("code"))
+        analyticService.track(AnalyticEvent.GetFeed("code", "userAgent"))
         analyticService.track(AnalyticEvent.RequestNewsletter("url"))
 
         // THEN

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspectTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspectTest.kt
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2024 Nicolas PICON
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package fr.nicopico.n2rss.analytics
+
+import fr.nicopico.n2rss.controller.home.HomeController
+import fr.nicopico.n2rss.controller.rss.RssFeedController
+import fr.nicopico.n2rss.mail.newsletter.NewsletterHandlerMultipleFeeds
+import fr.nicopico.n2rss.mail.newsletter.NewsletterHandlerSingleFeed
+import fr.nicopico.n2rss.models.Email
+import fr.nicopico.n2rss.models.Sender
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import jakarta.servlet.http.HttpServletRequest
+import kotlinx.datetime.LocalDate
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.ui.Model
+
+// TODO Disable access to MongoDB
+@SpringBootTest
+@Import(TestConfig::class)
+class AnalyticsAspectTest {
+
+    @Autowired
+    lateinit var analyticsService: AnalyticsService
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Nested
+    inner class HomeControllerTest {
+
+        @Autowired
+        lateinit var homeController: HomeController
+
+        @Test
+        fun `home success should trigger an analytic event`() {
+            // GIVEN
+            val request = mockk<HttpServletRequest>() {
+                every { requestURL } returns StringBuffer("https://www.google.com")
+            }
+            val model = mockk<Model>(relaxed = true)
+
+            // WHEN
+            homeController.home(request, model)
+
+            // THEN
+            verify { analyticsService.track(AnalyticsEvent.Home) }
+        }
+
+        @Test
+        fun `home error should trigger an analytic event`() {
+            // GIVEN
+            val request = mockk<HttpServletRequest>() {
+                every { requestURL } returns StringBuffer("https://www.google.com")
+            }
+            val model = mockk<Model>(relaxed = true)
+
+            // SETUP
+            every { homeController.home(any(), any()) } throws RuntimeException("TEST")
+
+            // WHEN
+            shouldThrowAny {
+                homeController.home(request, model)
+            }
+
+            // THEN
+            verify { analyticsService.track(AnalyticsEvent.Home) }
+            verify { analyticsService.track(AnalyticsEvent.Error.HomeError) }
+        }
+
+        @Test
+        fun `requestNewsletter success should trigger an analytic event`() {
+            // GIVEN
+            val newsletterUrl = "https://www.androidweekly.com"
+            val captchaResponse = ""
+
+            // WHEN
+            homeController.requestNewsletter(newsletterUrl, captchaResponse)
+
+            // THEN
+            verify { analyticsService.track(AnalyticsEvent.RequestNewsletter(newsletterUrl)) }
+        }
+
+        @Test
+        fun `requestNewsletter error should trigger an analytic event`() {
+            // GIVEN
+            val newsletterUrl = "https://www.androidweekly.com"
+            val captchaResponse = ""
+
+            // SETUP
+            every { homeController.requestNewsletter(any(), any()) } throws RuntimeException("TEST")
+
+            // WHEN
+            shouldThrowAny {
+                homeController.requestNewsletter(newsletterUrl, captchaResponse)
+            }
+
+            // THEN
+            verify { analyticsService.track(AnalyticsEvent.RequestNewsletter(newsletterUrl)) }
+            verify { analyticsService.track(AnalyticsEvent.Error.RequestNewsletterError) }
+        }
+    }
+
+    @Nested
+    inner class RssFeedControllerTest {
+
+        @Autowired
+        lateinit var rssFeedController: RssFeedController
+
+        @Test
+        fun `getRssFeeds success should trigger an analytic event`() {
+            // WHEN
+            rssFeedController.getRssFeeds()
+
+            // THEN
+            verify { analyticsService.track(AnalyticsEvent.GetRssFeeds) }
+        }
+
+        @Test
+        fun `getRssFeeds error should trigger an analytic event`() {
+            // SETUP
+            every { rssFeedController.getRssFeeds() } throws RuntimeException("TEST")
+
+            // WHEN
+            shouldThrowAny {
+                rssFeedController.getRssFeeds()
+            }
+
+            // THEN
+            verify { analyticsService.track(AnalyticsEvent.Error.GetRssFeedsError) }
+        }
+
+        @Test
+        fun `getFeed (code) success should trigger an analytic event`() {
+            // GIVEN
+            val feedCode = "stability"
+            val userAgent = "cord"
+
+            // WHEN
+            rssFeedController.getFeed(
+                code = feedCode,
+                publicationStart = 0,
+                publicationCount = 1,
+                response = mockk(),
+                userAgent = userAgent
+            )
+
+            // THEN
+            verify { analyticsService.track(AnalyticsEvent.GetFeed(feedCode, userAgent)) }
+        }
+
+        @Test
+        fun `getFeed (code) error should trigger an analytic event`() {
+            // GIVEN
+            val feedCode = "citizens"
+            val userAgent = "display"
+
+            // SETUP
+            every {
+                rssFeedController.getFeed(
+                    code = any(),
+                    publicationStart = any(),
+                    publicationCount = any(),
+                    response = any(),
+                    userAgent = any()
+                )
+            } throws RuntimeException("TEST")
+
+            // WHEN
+            shouldThrowAny {
+                rssFeedController.getFeed(
+                    code = feedCode,
+                    publicationStart = 0,
+                    publicationCount = 1,
+                    response = mockk(),
+                    userAgent = userAgent
+                )
+            }
+
+            // THEN
+            verify { analyticsService.track(AnalyticsEvent.GetFeed(feedCode, userAgent)) }
+            verify { analyticsService.track(AnalyticsEvent.Error.GetFeedError(feedCode)) }
+        }
+
+        @Test
+        fun `getFeed (folder) success should trigger an analytic event`() {
+            // GIVEN
+            val folder = "carlo"
+            val feed = "kevin"
+            val userAgent = "passed"
+
+            // WHEN
+            rssFeedController.getFeed(
+                folder = folder,
+                feed = feed,
+                publicationStart = 0,
+                publicationCount = 1,
+                response = mockk(),
+                userAgent = userAgent
+            )
+
+            // THEN
+            val feedCode = "$folder/$feed"
+            verify { analyticsService.track(AnalyticsEvent.GetFeed(feedCode, userAgent)) }
+        }
+
+        @Test
+        fun `getFeed (folder) error should trigger an analytic event`() {
+            // GIVEN
+            val folder = "independent"
+            val feed = "contemporary"
+            val userAgent = "clouds"
+
+            // SETUP
+            every {
+                rssFeedController.getFeed(
+                    folder = any(),
+                    feed = any(),
+                    publicationStart = any(),
+                    publicationCount = any(),
+                    response = any(),
+                    userAgent = any()
+                )
+            } throws RuntimeException("TEST")
+
+            // WHEN
+            shouldThrowAny {
+                rssFeedController.getFeed(
+                    folder = folder,
+                    feed = feed,
+                    publicationStart = 0,
+                    publicationCount = 1,
+                    response = mockk(),
+                    userAgent = userAgent
+                )
+            }
+
+            // THEN
+            val feedCode = "$folder/$feed"
+            verify { analyticsService.track(AnalyticsEvent.GetFeed(feedCode, userAgent)) }
+            verify { analyticsService.track(AnalyticsEvent.Error.GetFeedError(feedCode)) }
+        }
+    }
+
+    @Nested
+    inner class NewsletterHandler {
+        @Autowired
+        lateinit var newsletterHandlerSingleFeed: NewsletterHandlerSingleFeed
+        @Autowired
+        lateinit var newsletterHandlerMultipleFeeds: NewsletterHandlerMultipleFeeds
+
+        @Test
+        fun `SingeFeed - email parsing error should trigger an analytic event`() {
+            // GIVEN
+            val emailTitle = "Debate answered send collections tue."
+            val email = Email(
+                sender = Sender("foo@n2rss.fr"),
+                date = LocalDate(2024, 7, 20),
+                subject = emailTitle,
+                content = "Mark pennsylvania link granted viewing snap ellen, spell burst sales.",
+                msgnum = 0
+            )
+
+            // SETUP
+            every { newsletterHandlerSingleFeed.process(any()) } throws RuntimeException("TEST")
+
+            // WHEN
+            shouldThrowAny {
+                newsletterHandlerSingleFeed.process(email)
+            }
+
+            // THEN
+            val eventSlot = slot<AnalyticsEvent.Error.EmailParsingError>()
+            verify { analyticsService.track(capture(eventSlot)) }
+            assertSoftly(eventSlot.captured) { event ->
+                event.emailTitle shouldBe emailTitle
+                event.handlerName shouldStartWith "NewsletterHandlerSingleFeed"
+            }
+        }
+
+        @Test
+        fun `MultipleFeeds - email parsing error should trigger an analytic event`() {
+            // GIVEN
+            val emailTitle = "Accordingly absorption nsw commitment recognized camping archives"
+            val email = Email(
+                sender = Sender("foo@n2rss.fr"),
+                date = LocalDate(2024, 7, 20),
+                subject = emailTitle,
+                content = "Replacement islam traditional bruce connectivity boost theft, maritime dust south.",
+                msgnum = 0
+            )
+
+            // SETUP
+            every { newsletterHandlerMultipleFeeds.process(any()) } throws RuntimeException("TEST")
+
+            // WHEN
+            shouldThrowAny {
+                newsletterHandlerMultipleFeeds.process(email)
+            }
+
+            // THEN
+            val eventSlot = slot<AnalyticsEvent.Error.EmailParsingError>()
+            verify { analyticsService.track(capture(eventSlot)) }
+            assertSoftly(eventSlot.captured) { event ->
+                event.emailTitle shouldBe emailTitle
+                event.handlerName shouldStartWith "NewsletterHandlerMultipleFeeds"
+            }
+        }
+    }
+}
+
+@Configuration
+class TestConfig {
+    @Bean
+    fun analyticsService() = mockk<AnalyticsService>(relaxed = true)
+
+    @Bean
+    fun homeController() = mockk<HomeController>(relaxed = true)
+
+    @Bean
+    fun rssFeedController() = mockk<RssFeedController>(relaxed = true)
+
+    @Bean
+    fun newsletterHandlerSingleFeed() = mockk<NewsletterHandlerSingleFeed>(relaxed = true)
+
+    @Bean
+    fun newsletterHandlerMultipleFeeds() = mockk<NewsletterHandlerMultipleFeeds>(relaxed = true)
+}

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspectTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspectTest.kt
@@ -47,7 +47,7 @@ import org.springframework.context.annotation.Import
 import org.springframework.ui.Model
 
 // TODO Disable access to MongoDB
-@SpringBootTest
+@SpringBootTest()
 @Import(TestConfig::class)
 class AnalyticsAspectTest {
 
@@ -146,7 +146,6 @@ class AnalyticsAspectTest {
                 }
 
                 // THEN
-                verify { analyticsService.track(AnalyticsEvent.RequestNewsletter(newsletterUrl)) }
                 verify { analyticsService.track(AnalyticsEvent.Error.RequestNewsletterError) }
             }
 
@@ -256,7 +255,6 @@ class AnalyticsAspectTest {
                 }
 
                 // THEN
-                verify { analyticsService.track(AnalyticsEvent.GetFeed(feedCode, userAgent)) }
                 verify { analyticsService.track(AnalyticsEvent.Error.GetFeedError(feedCode)) }
             }
 
@@ -335,7 +333,6 @@ class AnalyticsAspectTest {
 
                 // THEN
                 val feedCode = "$folder/$feed"
-                verify { analyticsService.track(AnalyticsEvent.GetFeed(feedCode, userAgent)) }
                 verify { analyticsService.track(AnalyticsEvent.Error.GetFeedError(feedCode)) }
             }
 

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspectTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspectTest.kt
@@ -99,8 +99,9 @@ class AnalyticsAspectTest {
                 }
 
                 // THEN
-                verify { analyticsService.track(AnalyticsEvent.Home) }
                 verify { analyticsService.track(AnalyticsEvent.Error.HomeError) }
+                // NOTE: for some reason a Home event is sent before the HomeError event during the tests
+                // but only the error event is sent during a live execution
             }
 
             @Test

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspectTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspectTest.kt
@@ -24,6 +24,7 @@ import fr.nicopico.n2rss.mail.newsletter.NewsletterHandlerSingleFeed
 import fr.nicopico.n2rss.models.Email
 import fr.nicopico.n2rss.models.Sender
 import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldStartWith
@@ -33,6 +34,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import kotlinx.datetime.LocalDate
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Nested
@@ -63,72 +65,100 @@ class AnalyticsAspectTest {
         @Autowired
         lateinit var homeController: HomeController
 
-        @Test
-        fun `home success should trigger an analytic event`() {
-            // GIVEN
-            val request = mockk<HttpServletRequest>() {
-                every { requestURL } returns StringBuffer("https://www.google.com")
-            }
-            val model = mockk<Model>(relaxed = true)
+        @Nested
+        inner class Home {
+            @Test
+            fun `success should trigger an analytic event`() {
+                // GIVEN
+                val request = mockk<HttpServletRequest>() {
+                    every { requestURL } returns StringBuffer("https://www.google.com")
+                }
+                val model = mockk<Model>(relaxed = true)
 
-            // WHEN
-            homeController.home(request, model)
-
-            // THEN
-            verify { analyticsService.track(AnalyticsEvent.Home) }
-        }
-
-        @Test
-        fun `home error should trigger an analytic event`() {
-            // GIVEN
-            val request = mockk<HttpServletRequest>() {
-                every { requestURL } returns StringBuffer("https://www.google.com")
-            }
-            val model = mockk<Model>(relaxed = true)
-
-            // SETUP
-            every { homeController.home(any(), any()) } throws RuntimeException("TEST")
-
-            // WHEN
-            shouldThrowAny {
+                // WHEN
                 homeController.home(request, model)
+
+                // THEN
+                verify { analyticsService.track(AnalyticsEvent.Home) }
             }
 
-            // THEN
-            verify { analyticsService.track(AnalyticsEvent.Home) }
-            verify { analyticsService.track(AnalyticsEvent.Error.HomeError) }
+            @Test
+            fun `error should trigger an analytic event`() {
+                // GIVEN
+                val request = mockk<HttpServletRequest>() {
+                    every { requestURL } returns StringBuffer("https://www.google.com")
+                }
+                val model = mockk<Model>(relaxed = true)
+
+                // SETUP
+                every { homeController.home(any(), any()) } throws RuntimeException("TEST")
+
+                // WHEN
+                shouldThrowAny {
+                    homeController.home(request, model)
+                }
+
+                // THEN
+                verify { analyticsService.track(AnalyticsEvent.Home) }
+                verify { analyticsService.track(AnalyticsEvent.Error.HomeError) }
+            }
+
+            @Test
+            fun `analytics error should not propagate`() {
+                // GIVEN
+                every { analyticsService.track(any()) } throws AnalyticsException()
+
+                // WHEN - THEN
+                shouldNotThrowAny {
+                    homeController.home(mockk(), mockk())
+                }
+            }
         }
 
-        @Test
-        fun `requestNewsletter success should trigger an analytic event`() {
-            // GIVEN
-            val newsletterUrl = "https://www.androidweekly.com"
-            val captchaResponse = ""
+        @Nested
+        inner class RequestNewsletter {
+            @Test
+            fun `requestNewsletter success should trigger an analytic event`() {
+                // GIVEN
+                val newsletterUrl = "https://www.androidweekly.com"
+                val captchaResponse = ""
 
-            // WHEN
-            homeController.requestNewsletter(newsletterUrl, captchaResponse)
-
-            // THEN
-            verify { analyticsService.track(AnalyticsEvent.RequestNewsletter(newsletterUrl)) }
-        }
-
-        @Test
-        fun `requestNewsletter error should trigger an analytic event`() {
-            // GIVEN
-            val newsletterUrl = "https://www.androidweekly.com"
-            val captchaResponse = ""
-
-            // SETUP
-            every { homeController.requestNewsletter(any(), any()) } throws RuntimeException("TEST")
-
-            // WHEN
-            shouldThrowAny {
+                // WHEN
                 homeController.requestNewsletter(newsletterUrl, captchaResponse)
+
+                // THEN
+                verify { analyticsService.track(AnalyticsEvent.RequestNewsletter(newsletterUrl)) }
             }
 
-            // THEN
-            verify { analyticsService.track(AnalyticsEvent.RequestNewsletter(newsletterUrl)) }
-            verify { analyticsService.track(AnalyticsEvent.Error.RequestNewsletterError) }
+            @Test
+            fun `requestNewsletter error should trigger an analytic event`() {
+                // GIVEN
+                val newsletterUrl = "https://www.androidweekly.com"
+                val captchaResponse = ""
+
+                // SETUP
+                every { homeController.requestNewsletter(any(), any()) } throws RuntimeException("TEST")
+
+                // WHEN
+                shouldThrowAny {
+                    homeController.requestNewsletter(newsletterUrl, captchaResponse)
+                }
+
+                // THEN
+                verify { analyticsService.track(AnalyticsEvent.RequestNewsletter(newsletterUrl)) }
+                verify { analyticsService.track(AnalyticsEvent.Error.RequestNewsletterError) }
+            }
+
+            @Test
+            fun `analytics error should not propagate`() {
+                // GIVEN
+                every { analyticsService.track(any()) } throws AnalyticsException()
+
+                // WHEN - THEN
+                shouldNotThrowAny {
+                    homeController.requestNewsletter("some-url", "")
+                }
+            }
         }
     }
 
@@ -138,67 +168,52 @@ class AnalyticsAspectTest {
         @Autowired
         lateinit var rssFeedController: RssFeedController
 
-        @Test
-        fun `getRssFeeds success should trigger an analytic event`() {
-            // WHEN
-            rssFeedController.getRssFeeds()
-
-            // THEN
-            verify { analyticsService.track(AnalyticsEvent.GetRssFeeds) }
-        }
-
-        @Test
-        fun `getRssFeeds error should trigger an analytic event`() {
-            // SETUP
-            every { rssFeedController.getRssFeeds() } throws RuntimeException("TEST")
-
-            // WHEN
-            shouldThrowAny {
+        @Nested
+        inner class GetRssFeeds {
+            @Test
+            fun `getRssFeeds success should trigger an analytic event`() {
+                // WHEN
                 rssFeedController.getRssFeeds()
+
+                // THEN
+                verify { analyticsService.track(AnalyticsEvent.GetRssFeeds) }
             }
 
-            // THEN
-            verify { analyticsService.track(AnalyticsEvent.Error.GetRssFeedsError) }
+            @Test
+            fun `getRssFeeds error should trigger an analytic event`() {
+                // SETUP
+                every { rssFeedController.getRssFeeds() } throws RuntimeException("TEST")
+
+                // WHEN
+                shouldThrowAny {
+                    rssFeedController.getRssFeeds()
+                }
+
+                // THEN
+                verify { analyticsService.track(AnalyticsEvent.Error.GetRssFeedsError) }
+            }
+
+            @Test
+            fun `analytics error should not propagate`() {
+                // GIVEN
+                every { analyticsService.track(any()) } throws AnalyticsException()
+
+                // WHEN - THEN
+                shouldNotThrowAny {
+                    rssFeedController.getRssFeeds()
+                }
+            }
         }
 
-        @Test
-        fun `getFeed (code) success should trigger an analytic event`() {
-            // GIVEN
-            val feedCode = "stability"
-            val userAgent = "cord"
+        @Nested
+        inner class GetFeedByCode {
+            @Test
+            fun `getFeed (code) success should trigger an analytic event`() {
+                // GIVEN
+                val feedCode = "stability"
+                val userAgent = "cord"
 
-            // WHEN
-            rssFeedController.getFeed(
-                code = feedCode,
-                publicationStart = 0,
-                publicationCount = 1,
-                response = mockk(),
-                userAgent = userAgent
-            )
-
-            // THEN
-            verify { analyticsService.track(AnalyticsEvent.GetFeed(feedCode, userAgent)) }
-        }
-
-        @Test
-        fun `getFeed (code) error should trigger an analytic event`() {
-            // GIVEN
-            val feedCode = "citizens"
-            val userAgent = "display"
-
-            // SETUP
-            every {
-                rssFeedController.getFeed(
-                    code = any(),
-                    publicationStart = any(),
-                    publicationCount = any(),
-                    response = any(),
-                    userAgent = any()
-                )
-            } throws RuntimeException("TEST")
-
-            // WHEN
-            shouldThrowAny {
+                // WHEN
                 rssFeedController.getFeed(
                     code = feedCode,
                     publicationStart = 0,
@@ -206,56 +221,72 @@ class AnalyticsAspectTest {
                     response = mockk(),
                     userAgent = userAgent
                 )
+
+                // THEN
+                verify { analyticsService.track(AnalyticsEvent.GetFeed(feedCode, userAgent)) }
             }
 
-            // THEN
-            verify { analyticsService.track(AnalyticsEvent.GetFeed(feedCode, userAgent)) }
-            verify { analyticsService.track(AnalyticsEvent.Error.GetFeedError(feedCode)) }
+            @Test
+            fun `getFeed (code) error should trigger an analytic event`() {
+                // GIVEN
+                val feedCode = "citizens"
+                val userAgent = "display"
+
+                // SETUP
+                every {
+                    rssFeedController.getFeed(
+                        code = any(),
+                        publicationStart = any(),
+                        publicationCount = any(),
+                        response = any(),
+                        userAgent = any()
+                    )
+                } throws RuntimeException("TEST")
+
+                // WHEN
+                shouldThrowAny {
+                    rssFeedController.getFeed(
+                        code = feedCode,
+                        publicationStart = 0,
+                        publicationCount = 1,
+                        response = mockk(),
+                        userAgent = userAgent
+                    )
+                }
+
+                // THEN
+                verify { analyticsService.track(AnalyticsEvent.GetFeed(feedCode, userAgent)) }
+                verify { analyticsService.track(AnalyticsEvent.Error.GetFeedError(feedCode)) }
+            }
+
+            @Test
+            fun `analytics error should not propagate`() {
+                // GIVEN
+                every { analyticsService.track(any()) } throws AnalyticsException()
+
+                // WHEN - THEN
+                shouldNotThrowAny {
+                    rssFeedController.getFeed(
+                        code = "",
+                        publicationStart = 0,
+                        publicationCount = 0,
+                        response = mockk(),
+                        userAgent = ""
+                    )
+                }
+            }
         }
 
-        @Test
-        fun `getFeed (folder) success should trigger an analytic event`() {
-            // GIVEN
-            val folder = "carlo"
-            val feed = "kevin"
-            val userAgent = "passed"
+        @Nested
+        inner class GetFeedByFolderAndCode {
+            @Test
+            fun `getFeed (folder) success should trigger an analytic event`() {
+                // GIVEN
+                val folder = "carlo"
+                val feed = "kevin"
+                val userAgent = "passed"
 
-            // WHEN
-            rssFeedController.getFeed(
-                folder = folder,
-                feed = feed,
-                publicationStart = 0,
-                publicationCount = 1,
-                response = mockk(),
-                userAgent = userAgent
-            )
-
-            // THEN
-            val feedCode = "$folder/$feed"
-            verify { analyticsService.track(AnalyticsEvent.GetFeed(feedCode, userAgent)) }
-        }
-
-        @Test
-        fun `getFeed (folder) error should trigger an analytic event`() {
-            // GIVEN
-            val folder = "independent"
-            val feed = "contemporary"
-            val userAgent = "clouds"
-
-            // SETUP
-            every {
-                rssFeedController.getFeed(
-                    folder = any(),
-                    feed = any(),
-                    publicationStart = any(),
-                    publicationCount = any(),
-                    response = any(),
-                    userAgent = any()
-                )
-            } throws RuntimeException("TEST")
-
-            // WHEN
-            shouldThrowAny {
+                // WHEN
                 rssFeedController.getFeed(
                     folder = folder,
                     feed = feed,
@@ -264,12 +295,66 @@ class AnalyticsAspectTest {
                     response = mockk(),
                     userAgent = userAgent
                 )
+
+                // THEN
+                val feedCode = "$folder/$feed"
+                verify { analyticsService.track(AnalyticsEvent.GetFeed(feedCode, userAgent)) }
             }
 
-            // THEN
-            val feedCode = "$folder/$feed"
-            verify { analyticsService.track(AnalyticsEvent.GetFeed(feedCode, userAgent)) }
-            verify { analyticsService.track(AnalyticsEvent.Error.GetFeedError(feedCode)) }
+            @Test
+            fun `getFeed (folder) error should trigger an analytic event`() {
+                // GIVEN
+                val folder = "independent"
+                val feed = "contemporary"
+                val userAgent = "clouds"
+
+                // SETUP
+                every {
+                    rssFeedController.getFeed(
+                        folder = any(),
+                        feed = any(),
+                        publicationStart = any(),
+                        publicationCount = any(),
+                        response = any(),
+                        userAgent = any()
+                    )
+                } throws RuntimeException("TEST")
+
+                // WHEN
+                shouldThrowAny {
+                    rssFeedController.getFeed(
+                        folder = folder,
+                        feed = feed,
+                        publicationStart = 0,
+                        publicationCount = 1,
+                        response = mockk(),
+                        userAgent = userAgent
+                    )
+                }
+
+                // THEN
+                val feedCode = "$folder/$feed"
+                verify { analyticsService.track(AnalyticsEvent.GetFeed(feedCode, userAgent)) }
+                verify { analyticsService.track(AnalyticsEvent.Error.GetFeedError(feedCode)) }
+            }
+
+            @Test
+            fun `analytics error should not propagate`() {
+                // GIVEN
+                every { analyticsService.track(any()) } throws AnalyticsException()
+
+                // WHEN - THEN
+                shouldNotThrowAny {
+                    rssFeedController.getFeed(
+                        folder = "",
+                        feed = "",
+                        publicationStart = 0,
+                        publicationCount = 0,
+                        response = mockk<HttpServletResponse>(),
+                        userAgent = ""
+                    )
+                }
+            }
         }
     }
 

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspectTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspectTest.kt
@@ -51,7 +51,7 @@ import org.springframework.ui.Model
  * Events are sent that should not, Mocks configured to throw do not throw...
  * Probably some conflicts between Mocks and Aspect shenanigans
  *
- * TODO : Check if I can make it works better with https://github.com/mock4aj/mock4aj
+ * Check if I can make it works better with https://github.com/mock4aj/mock4aj ?
  */
 @ExtendWith(MockKExtension::class)
 class AnalyticsAspectTest {
@@ -237,8 +237,8 @@ class AnalyticsAspectTest {
                     code = feedCode,
                     publicationStart = 0,
                     publicationCount = 1,
-                    response = mockk(),
-                    userAgent = userAgent
+                    userAgent = userAgent,
+                    response = mockk()
                 )
 
                 // THEN
@@ -258,8 +258,8 @@ class AnalyticsAspectTest {
                         code = any(),
                         publicationStart = any(),
                         publicationCount = any(),
-                        response = any(),
-                        userAgent = any()
+                        userAgent = any(),
+                        response = any()
                     )
                 } throws RuntimeException("TEST")
 
@@ -269,8 +269,8 @@ class AnalyticsAspectTest {
                         code = feedCode,
                         publicationStart = 0,
                         publicationCount = 1,
-                        response = mockk(),
-                        userAgent = userAgent
+                        userAgent = userAgent,
+                        response = mockk()
                     )
                 }
 
@@ -289,8 +289,8 @@ class AnalyticsAspectTest {
                         code = "",
                         publicationStart = 0,
                         publicationCount = 0,
-                        response = mockk(),
-                        userAgent = ""
+                        userAgent = "",
+                        response = mockk()
                     )
                 }
             }
@@ -311,8 +311,8 @@ class AnalyticsAspectTest {
                     feed = feed,
                     publicationStart = 0,
                     publicationCount = 1,
-                    response = mockk(),
-                    userAgent = userAgent
+                    userAgent = userAgent,
+                    response = mockk()
                 )
 
                 // THEN
@@ -335,8 +335,8 @@ class AnalyticsAspectTest {
                         feed = any(),
                         publicationStart = any(),
                         publicationCount = any(),
-                        response = any(),
-                        userAgent = any()
+                        userAgent = any(),
+                        response = any()
                     )
                 } throws RuntimeException("TEST")
 
@@ -347,8 +347,8 @@ class AnalyticsAspectTest {
                         feed = feed,
                         publicationStart = 0,
                         publicationCount = 1,
-                        response = mockk(),
-                        userAgent = userAgent
+                        userAgent = userAgent,
+                        response = mockk()
                     )
                 }
 
@@ -369,8 +369,8 @@ class AnalyticsAspectTest {
                         feed = "",
                         publicationStart = 0,
                         publicationCount = 0,
-                        response = mockk<HttpServletResponse>(),
-                        userAgent = ""
+                        userAgent = "",
+                        response = mockk<HttpServletResponse>()
                     )
                 }
             }

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspectTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsAspectTest.kt
@@ -234,7 +234,7 @@ class AnalyticsAspectTest {
 
                 // WHEN
                 rssFeedController.getFeed(
-                    code = feedCode,
+                    feed = feedCode,
                     publicationStart = 0,
                     publicationCount = 1,
                     userAgent = userAgent,
@@ -255,7 +255,7 @@ class AnalyticsAspectTest {
                 // SETUP
                 every {
                     rssFeedController.getFeed(
-                        code = any(),
+                        feed = any(),
                         publicationStart = any(),
                         publicationCount = any(),
                         userAgent = any(),
@@ -266,7 +266,7 @@ class AnalyticsAspectTest {
                 // WHEN
                 shouldThrowAny {
                     rssFeedController.getFeed(
-                        code = feedCode,
+                        feed = feedCode,
                         publicationStart = 0,
                         publicationCount = 1,
                         userAgent = userAgent,
@@ -286,7 +286,7 @@ class AnalyticsAspectTest {
                 // WHEN - THEN
                 shouldNotThrowAny {
                     rssFeedController.getFeed(
-                        code = "",
+                        feed = "",
                         publicationStart = 0,
                         publicationCount = 0,
                         userAgent = "",

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsDataTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsDataTest.kt
@@ -43,14 +43,20 @@ class AnalyticsDataTest {
         @Suppress("LongMethod")
         fun provideEvents(): List<Arguments> = listOf(
             Arguments.of(
-                AnalyticsEvent.Home,
+                AnalyticsEvent.Home(
+                    userAgent = "user1"
+                ),
                 AnalyticsData(
                     code = "home",
+                    data = mapOf("userAgent" to "user1"),
                     timestamp = timestamp,
                 )
             ),
             Arguments.of(
-                AnalyticsEvent.GetFeed("feed1", "user1"),
+                AnalyticsEvent.GetFeed(
+                    feedCode = "feed1",
+                    userAgent = "user1"
+                ),
                 AnalyticsData(
                     code = "get-feed",
                     timestamp = timestamp,
@@ -58,15 +64,18 @@ class AnalyticsDataTest {
                 )
             ),
             Arguments.of(
-                AnalyticsEvent.RequestNewsletter("url1"),
+                AnalyticsEvent.RequestNewsletter(
+                    newsletterUrl = "url1",
+                    userAgent = "user1"
+                ),
                 AnalyticsData(
                     code = "request-newsletter",
                     timestamp = timestamp,
-                    data = mapOf("newsletterUrl" to "url1")
+                    data = mapOf("newsletterUrl" to "url1", "userAgent" to "user1")
                 )
             ),
             Arguments.of(
-                AnalyticsEvent.NewRelease("1.0.0"),
+                AnalyticsEvent.NewRelease(version = "1.0.0"),
                 AnalyticsData(
                     code = "release",
                     timestamp = timestamp,
@@ -81,7 +90,7 @@ class AnalyticsDataTest {
                 )
             ),
             Arguments.of(
-                AnalyticsEvent.Error.GetFeedError("feed1"),
+                AnalyticsEvent.Error.GetFeedError(feedCode = "feed1"),
                 AnalyticsData(
                     code = "error-get-feed",
                     timestamp = timestamp,
@@ -89,7 +98,10 @@ class AnalyticsDataTest {
                 )
             ),
             Arguments.of(
-                AnalyticsEvent.Error.EmailParsingError("handler1", "title1"),
+                AnalyticsEvent.Error.EmailParsingError(
+                    handlerName = "handler1",
+                    emailTitle = "title1"
+                ),
                 AnalyticsData(
                     code = "error-parsing",
                     timestamp = timestamp,
@@ -104,9 +116,12 @@ class AnalyticsDataTest {
                 )
             ),
             Arguments.of(
-                AnalyticsEvent.GetRssFeeds,
+                AnalyticsEvent.GetRssFeeds(
+                    userAgent = "user1",
+                ),
                 AnalyticsData(
                     code = "get-rss-feeds",
+                    data = mapOf("userAgent" to "user1"),
                     timestamp = timestamp,
                 )
             ),

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsDataTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsDataTest.kt
@@ -40,6 +40,7 @@ class AnalyticsDataTest {
         val timestamp = Clock.System.now()
 
         @JvmStatic
+        @Suppress("LongMethod")
         fun provideEvents(): List<Arguments> = listOf(
             Arguments.of(
                 AnalyticsEvent.Home,
@@ -101,7 +102,7 @@ class AnalyticsDataTest {
                     code = "error-request-newsletter",
                     timestamp = timestamp
                 )
-            )
+            ),
         )
     }
 

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsDataTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsDataTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024 Nicolas PICON
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package fr.nicopico.n2rss.analytics
+
+import fr.nicopico.n2rss.analytics.data.AnalyticsData
+import fr.nicopico.n2rss.analytics.data.toAnalyticsData
+import io.kotest.matchers.shouldBe
+import kotlinx.datetime.Clock
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class AnalyticsDataTest {
+
+    @ParameterizedTest
+    @MethodSource("provideEvents")
+    fun `AnalyticEvent should convert to AnalyticsData`(
+        event: AnalyticEvent, expected: AnalyticsData,
+    ) {
+        val actual = event.toAnalyticsData(timestamp)
+        actual shouldBe expected
+    }
+
+    companion object {
+        val timestamp = Clock.System.now()
+
+        @JvmStatic
+        fun provideEvents(): List<Arguments> = listOf(
+            Arguments.of(
+                AnalyticEvent.Home,
+                AnalyticsData(
+                    code = "home",
+                    timestamp = timestamp,
+                )
+            ),
+            Arguments.of(
+                AnalyticEvent.GetFeed("feed1", "user1"),
+                AnalyticsData(
+                    code = "get-feed",
+                    timestamp = timestamp,
+                    data = mapOf("feedCode" to "feed1", "userAgent" to "user1")
+                )
+            ),
+            Arguments.of(
+                AnalyticEvent.RequestNewsletter("url1"),
+                AnalyticsData(
+                    code = "request-newsletter",
+                    timestamp = timestamp,
+                    data = mapOf("newsletterUrl" to "url1")
+                )
+            ),
+            Arguments.of(
+                AnalyticEvent.NewRelease("1.0.0"),
+                AnalyticsData(
+                    code = "release",
+                    timestamp = timestamp,
+                    data = mapOf("version" to "1.0.0")
+                )
+            ),
+            Arguments.of(
+                AnalyticEvent.Error.HomeError,
+                AnalyticsData(
+                    code = "error-home",
+                    timestamp = timestamp
+                )
+            ),
+            Arguments.of(
+                AnalyticEvent.Error.GetFeedError("feed1"),
+                AnalyticsData(
+                    code = "error-get-feed",
+                    timestamp = timestamp,
+                    data = mapOf("feedCode" to "feed1")
+                )
+            ),
+            Arguments.of(
+                AnalyticEvent.Error.EmailParsingError("handler1", "title1"),
+                AnalyticsData(
+                    code = "error-parsing",
+                    timestamp = timestamp,
+                    data = mapOf("handlerName" to "handler1", "emailTitle" to "title1")
+                )
+            ),
+            Arguments.of(
+                AnalyticEvent.Error.RequestNewsletterError,
+                AnalyticsData(
+                    code = "error-request-newsletter",
+                    timestamp = timestamp
+                )
+            )
+        )
+    }
+
+}

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsDataTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsDataTest.kt
@@ -30,7 +30,7 @@ class AnalyticsDataTest {
     @ParameterizedTest
     @MethodSource("provideEvents")
     fun `AnalyticEvent should convert to AnalyticsData`(
-        event: AnalyticEvent, expected: AnalyticsData,
+        event: AnalyticsEvent, expected: AnalyticsData,
     ) {
         val actual = event.toAnalyticsData(timestamp)
         actual shouldBe expected
@@ -42,14 +42,14 @@ class AnalyticsDataTest {
         @JvmStatic
         fun provideEvents(): List<Arguments> = listOf(
             Arguments.of(
-                AnalyticEvent.Home,
+                AnalyticsEvent.Home,
                 AnalyticsData(
                     code = "home",
                     timestamp = timestamp,
                 )
             ),
             Arguments.of(
-                AnalyticEvent.GetFeed("feed1", "user1"),
+                AnalyticsEvent.GetFeed("feed1", "user1"),
                 AnalyticsData(
                     code = "get-feed",
                     timestamp = timestamp,
@@ -57,7 +57,7 @@ class AnalyticsDataTest {
                 )
             ),
             Arguments.of(
-                AnalyticEvent.RequestNewsletter("url1"),
+                AnalyticsEvent.RequestNewsletter("url1"),
                 AnalyticsData(
                     code = "request-newsletter",
                     timestamp = timestamp,
@@ -65,7 +65,7 @@ class AnalyticsDataTest {
                 )
             ),
             Arguments.of(
-                AnalyticEvent.NewRelease("1.0.0"),
+                AnalyticsEvent.NewRelease("1.0.0"),
                 AnalyticsData(
                     code = "release",
                     timestamp = timestamp,
@@ -73,14 +73,14 @@ class AnalyticsDataTest {
                 )
             ),
             Arguments.of(
-                AnalyticEvent.Error.HomeError,
+                AnalyticsEvent.Error.HomeError,
                 AnalyticsData(
                     code = "error-home",
                     timestamp = timestamp
                 )
             ),
             Arguments.of(
-                AnalyticEvent.Error.GetFeedError("feed1"),
+                AnalyticsEvent.Error.GetFeedError("feed1"),
                 AnalyticsData(
                     code = "error-get-feed",
                     timestamp = timestamp,
@@ -88,7 +88,7 @@ class AnalyticsDataTest {
                 )
             ),
             Arguments.of(
-                AnalyticEvent.Error.EmailParsingError("handler1", "title1"),
+                AnalyticsEvent.Error.EmailParsingError("handler1", "title1"),
                 AnalyticsData(
                     code = "error-parsing",
                     timestamp = timestamp,
@@ -96,7 +96,7 @@ class AnalyticsDataTest {
                 )
             ),
             Arguments.of(
-                AnalyticEvent.Error.RequestNewsletterError,
+                AnalyticsEvent.Error.RequestNewsletterError,
                 AnalyticsData(
                     code = "error-request-newsletter",
                     timestamp = timestamp

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsDataTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsDataTest.kt
@@ -103,6 +103,20 @@ class AnalyticsDataTest {
                     timestamp = timestamp
                 )
             ),
+            Arguments.of(
+                AnalyticsEvent.GetRssFeeds,
+                AnalyticsData(
+                    code = "get-rss-feeds",
+                    timestamp = timestamp,
+                )
+            ),
+            Arguments.of(
+                AnalyticsEvent.Error.GetRssFeedsError,
+                AnalyticsData(
+                    code = "error-get-rss-feeds",
+                    timestamp = timestamp,
+                )
+            )
         )
     }
 

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsDataTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsDataTest.kt
@@ -39,39 +39,42 @@ class AnalyticsDataTest {
     companion object {
         val timestamp = Clock.System.now()
 
+        private const val UA = "user1"
+        private const val UA_FINGERPRINT = "0a041b9462caa4a31bac3567e0b6e6fd9100787db2ab433d96f6d178cabfce90"
+
         @JvmStatic
         @Suppress("LongMethod")
         fun provideEvents(): List<Arguments> = listOf(
             Arguments.of(
                 AnalyticsEvent.Home(
-                    userAgent = "user1"
+                    userAgent = UA
                 ),
                 AnalyticsData(
                     code = "home",
-                    data = mapOf("userAgent" to "user1"),
+                    data = mapOf("userAgent" to UA_FINGERPRINT),
                     timestamp = timestamp,
                 )
             ),
             Arguments.of(
                 AnalyticsEvent.GetFeed(
                     feedCode = "feed1",
-                    userAgent = "user1"
+                    userAgent = UA
                 ),
                 AnalyticsData(
                     code = "get-feed",
                     timestamp = timestamp,
-                    data = mapOf("feedCode" to "feed1", "userAgent" to "user1")
+                    data = mapOf("feedCode" to "feed1", "userAgent" to UA_FINGERPRINT)
                 )
             ),
             Arguments.of(
                 AnalyticsEvent.RequestNewsletter(
                     newsletterUrl = "url1",
-                    userAgent = "user1"
+                    userAgent = UA
                 ),
                 AnalyticsData(
                     code = "request-newsletter",
                     timestamp = timestamp,
-                    data = mapOf("newsletterUrl" to "url1", "userAgent" to "user1")
+                    data = mapOf("newsletterUrl" to "url1", "userAgent" to UA_FINGERPRINT)
                 )
             ),
             Arguments.of(
@@ -117,11 +120,11 @@ class AnalyticsDataTest {
             ),
             Arguments.of(
                 AnalyticsEvent.GetRssFeeds(
-                    userAgent = "user1",
+                    userAgent = UA,
                 ),
                 AnalyticsData(
                     code = "get-rss-feeds",
-                    data = mapOf("userAgent" to "user1"),
+                    data = mapOf("userAgent" to UA_FINGERPRINT),
                     timestamp = timestamp,
                 )
             ),

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsServiceTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/AnalyticsServiceTest.kt
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import io.kotest.matchers.string.beEmpty as beAnEmptyString
 
-class AnalyticServiceTest {
+class AnalyticsServiceTest {
 
     @MockK
     private lateinit var analyticsRepository: AnalyticsRepository
@@ -47,8 +47,8 @@ class AnalyticServiceTest {
         every { analyticsRepository.save(any()) } answers { firstArg() }
     }
 
-    private fun createAnalyticService(enabled: Boolean = true): AnalyticService {
-        return AnalyticService(
+    private fun createAnalyticService(enabled: Boolean = true): AnalyticsService {
+        return AnalyticsService(
             analyticsRepository = analyticsRepository,
             analyticsProperties = N2RssProperties.AnalyticsProperties(
                 enabled = enabled,
@@ -61,11 +61,11 @@ class AnalyticServiceTest {
         // GIVEN
         val analyticService = createAnalyticService()
         val data = mockk<AnalyticsData>()
-        val event = mockk<AnalyticEvent>()
+        val event = mockk<AnalyticsEvent>()
 
         // SETUP
-        mockkStatic(AnalyticEvent::toAnalyticsData) {
-            every { any<AnalyticEvent>().toAnalyticsData(any()) } returns data
+        mockkStatic(AnalyticsEvent::toAnalyticsData) {
+            every { any<AnalyticsEvent>().toAnalyticsData(any()) } returns data
 
             // WHEN
             analyticService.track(event)
@@ -86,8 +86,8 @@ class AnalyticServiceTest {
         every { analyticsRepository.save(any()) } throws internalError
 
         // WHEN - THEN
-        val error = shouldThrow<AnalyticException> {
-            analyticService.track(AnalyticEvent.GetFeed("code", "userAgent"))
+        val error = shouldThrow<AnalyticsException> {
+            analyticService.track(AnalyticsEvent.GetFeed("code", "userAgent"))
         }
         error.message shouldNot beAnEmptyString()
         error.cause shouldBe internalError
@@ -97,7 +97,7 @@ class AnalyticServiceTest {
     fun `No events should be sent if analytics is disabled`() {
         // GIVEN
         val analyticService = createAnalyticService(enabled = false)
-        val event = mockk<AnalyticEvent>()
+        val event = mockk<AnalyticsEvent>()
 
         // WHEN
         analyticService.track(event)

--- a/src/test/kotlin/fr/nicopico/n2rss/controller/home/HomeControllerTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/controller/home/HomeControllerTest.kt
@@ -53,6 +53,8 @@ class HomeControllerTest {
 
     private lateinit var homeController: HomeController
 
+    private val userAgent = "USER_AGENT"
+
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
@@ -119,7 +121,7 @@ class HomeControllerTest {
             val model = mockk<Model>(relaxed = true)
 
             // WHEN
-            val result = homeController.home(request, model)
+            val result = homeController.home(request, model, userAgent)
 
             // THEN
             result shouldBe "index"
@@ -189,7 +191,7 @@ class HomeControllerTest {
             val model = mockk<Model>(relaxed = true)
 
             // WHEN
-            val result = homeController.home(request, model)
+            val result = homeController.home(request, model, userAgent)
 
             // THEN
             result shouldBe "index"
@@ -221,7 +223,7 @@ class HomeControllerTest {
             val model = mockk<Model>(relaxed = true)
 
             // WHEN
-            val result = homeController.home(request, model)
+            val result = homeController.home(request, model, userAgent)
 
             // THEN
             result shouldBe "index"
@@ -248,7 +250,7 @@ class HomeControllerTest {
             every { reCaptchaService.isCaptchaValid(any(), any()) } returns true
 
             // WHEN
-            val response = homeController.requestNewsletter(newsletterUrl, captchaResponse)
+            val response = homeController.requestNewsletter(newsletterUrl, captchaResponse, userAgent)
 
             // THEN
             verify { newsletterService.saveRequest(URL(newsletterUrl)) }
@@ -269,7 +271,7 @@ class HomeControllerTest {
             every { reCaptchaService.isCaptchaValid(any(), any()) } returns false
 
             // WHEN
-            val response = homeController.requestNewsletter(newsletterUrl, captchaResponse)
+            val response = homeController.requestNewsletter(newsletterUrl, captchaResponse, userAgent)
 
             // THEN
             verify(exactly = 0) { newsletterService.saveRequest(any()) }
@@ -286,7 +288,7 @@ class HomeControllerTest {
             every { newsletterService.saveRequest(any()) } just Runs
 
             // WHEN
-            val response = homeController.requestNewsletter(newsletterUrl)
+            val response = homeController.requestNewsletter(newsletterUrl, userAgent = userAgent)
 
             // THEN
             verify(exactly = 1) { newsletterService.saveRequest(any()) }
@@ -305,7 +307,7 @@ class HomeControllerTest {
             every { newsletterService.saveRequest(any()) } just Runs
 
             // WHEN
-            homeController.requestNewsletter(newsletterUrl, captchaResponse)
+            homeController.requestNewsletter(newsletterUrl, captchaResponse, userAgent)
 
             // THEN
             val slotUrl = slot<URL>()

--- a/src/test/kotlin/fr/nicopico/n2rss/controller/maintenance/MaintenanceControllerTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/controller/maintenance/MaintenanceControllerTest.kt
@@ -17,7 +17,7 @@
  */
 package fr.nicopico.n2rss.controller.maintenance
 
-import fr.nicopico.n2rss.analytics.AnalyticService
+import fr.nicopico.n2rss.analytics.AnalyticsService
 import fr.nicopico.n2rss.config.N2RssProperties
 import io.mockk.MockKAnnotations
 import io.mockk.every
@@ -40,7 +40,7 @@ class MaintenanceControllerTest {
     @AdditionalInterface(ConfigurableApplicationContext::class)
     private lateinit var applicationContext: ApplicationContext
     @MockK
-    private lateinit var analyticService: AnalyticService
+    private lateinit var analyticsService: AnalyticsService
     @MockK
     private lateinit var maintenanceProps: N2RssProperties.MaintenanceProperties
 
@@ -49,7 +49,7 @@ class MaintenanceControllerTest {
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
-        controller = MaintenanceController(applicationContext, analyticService, maintenanceProps)
+        controller = MaintenanceController(applicationContext, analyticsService, maintenanceProps)
 
         mockkStatic(SpringApplication::class)
         every { SpringApplication.exit(any()) } returns 0

--- a/src/test/kotlin/fr/nicopico/n2rss/controller/maintenance/MaintenanceControllerTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/controller/maintenance/MaintenanceControllerTest.kt
@@ -15,9 +15,9 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
 package fr.nicopico.n2rss.controller.maintenance
 
+import fr.nicopico.n2rss.analytics.AnalyticService
 import fr.nicopico.n2rss.config.N2RssProperties
 import io.mockk.MockKAnnotations
 import io.mockk.every
@@ -33,11 +33,14 @@ import org.springframework.boot.SpringApplication
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ConfigurableApplicationContext
 
+// TODO Test MaintenanceController.notifyRelease() endpoint
 class MaintenanceControllerTest {
 
     @MockK
     @AdditionalInterface(ConfigurableApplicationContext::class)
     private lateinit var applicationContext: ApplicationContext
+    @MockK
+    private lateinit var analyticService: AnalyticService
     @MockK
     private lateinit var maintenanceProps: N2RssProperties.MaintenanceProperties
 
@@ -46,7 +49,7 @@ class MaintenanceControllerTest {
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
-        controller = MaintenanceController(applicationContext, maintenanceProps)
+        controller = MaintenanceController(applicationContext, analyticService, maintenanceProps)
 
         mockkStatic(SpringApplication::class)
         every { SpringApplication.exit(any()) } returns 0

--- a/src/test/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedControllerTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedControllerTest.kt
@@ -94,7 +94,7 @@ class RssFeedControllerTest {
         every { rssService.getFeed(any(), any(), any()) } returns feed
 
         // WHEN
-        rssFeedController.getFeed("test", 0, 2, mockResponse, "userAgent")
+        rssFeedController.getFeed("test", 0, 2, "userAgent", mockResponse)
 
         // THEN
         verifySequence {
@@ -112,7 +112,7 @@ class RssFeedControllerTest {
         every { rssService.getFeed(any(), any(), any()) } returns feed
 
         // WHEN
-        rssFeedController.getFeed("folder", "test", 0, 2, mockResponse, "userAgent")
+        rssFeedController.getFeed("folder", "test", 0, 2, "userAgent", mockResponse)
 
         // THEN
         verifySequence {
@@ -128,7 +128,7 @@ class RssFeedControllerTest {
         every { rssService.getFeed(any(), any(), any()) } throws NoSuchElementException()
 
         // WHEN-THEN
-        rssFeedController.getFeed("test", 0, 2, mockResponse, "userAgent")
+        rssFeedController.getFeed("test", 0, 2, "userAgent", mockResponse)
 
         // THEN
         verifySequence {

--- a/src/test/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedControllerTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedControllerTest.kt
@@ -94,7 +94,7 @@ class RssFeedControllerTest {
         every { rssService.getFeed(any(), any(), any()) } returns feed
 
         // WHEN
-        rssFeedController.getFeed("test", 0, 2, mockResponse)
+        rssFeedController.getFeed("test", 0, 2, mockResponse, "userAgent")
 
         // THEN
         verifySequence {
@@ -112,7 +112,7 @@ class RssFeedControllerTest {
         every { rssService.getFeed(any(), any(), any()) } returns feed
 
         // WHEN
-        rssFeedController.getFeed("folder", "test", 0, 2, mockResponse)
+        rssFeedController.getFeed("folder", "test", 0, 2, mockResponse, "userAgent")
 
         // THEN
         verifySequence {
@@ -128,7 +128,7 @@ class RssFeedControllerTest {
         every { rssService.getFeed(any(), any(), any()) } throws NoSuchElementException()
 
         // WHEN-THEN
-        rssFeedController.getFeed("test", 0, 2, mockResponse)
+        rssFeedController.getFeed("test", 0, 2, mockResponse, "userAgent")
 
         // THEN
         verifySequence {

--- a/src/test/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedControllerTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedControllerTest.kt
@@ -71,7 +71,7 @@ class RssFeedControllerTest {
         }
 
         // WHEN
-        val result = rssFeedController.getRssFeeds()
+        val result = rssFeedController.getRssFeeds("userAgent")
 
         // THEN
         result shouldHaveSize 2

--- a/src/test/kotlin/fr/nicopico/n2rss/data/CleanLocalDatabaseTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/data/CleanLocalDatabaseTest.kt
@@ -1,5 +1,24 @@
+/*
+ * Copyright (c) 2024 Nicolas PICON
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
 package fr.nicopico.n2rss.data
 
+import fr.nicopico.n2rss.analytics.data.AnalyticsRepository
 import io.mockk.MockKAnnotations
 import io.mockk.confirmVerified
 import io.mockk.impl.annotations.MockK
@@ -13,13 +32,21 @@ class CleanLocalDatabaseTest {
 
     @MockK(relaxUnitFun = true)
     private lateinit var publicationRepository: PublicationRepository
+    @MockK(relaxUnitFun = true)
+    private lateinit var newsletterRequestRepository: NewsletterRequestRepository
+    @MockK(relaxUnitFun = true)
+    private lateinit var analyticsRepository: AnalyticsRepository
 
     private lateinit var cleanLocalDatabase: CleanLocalDatabase
 
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
-        cleanLocalDatabase = CleanLocalDatabase(publicationRepository)
+        cleanLocalDatabase = CleanLocalDatabase(
+            publicationRepository,
+            newsletterRequestRepository,
+            analyticsRepository,
+        )
     }
 
     @Test
@@ -31,7 +58,15 @@ class CleanLocalDatabaseTest {
         cleanLocalDatabase.onApplicationEvent(anyEvent)
 
         // THEN
-        verify(exactly = 1) { publicationRepository.deleteAll() }
-        confirmVerified(publicationRepository)
+        verify(exactly = 1) {
+            publicationRepository.deleteAll()
+            newsletterRequestRepository.deleteAll()
+            analyticsRepository.deleteAll()
+        }
+        confirmVerified(
+            publicationRepository,
+            newsletterRequestRepository,
+            analyticsRepository,
+        )
     }
 }

--- a/src/test/kotlin/fr/nicopico/n2rss/fakes/NewsletterHandlerFake.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/fakes/NewsletterHandlerFake.kt
@@ -15,7 +15,6 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
 package fr.nicopico.n2rss.fakes
 
 import fr.nicopico.n2rss.mail.newsletter.NewsletterHandler

--- a/src/test/kotlin/fr/nicopico/n2rss/utils/AspectUtilsKtTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/utils/AspectUtilsKtTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024 Nicolas PICON
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package fr.nicopico.n2rss.utils
+
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.ProceedingJoinPoint
+import org.junit.jupiter.api.Test
+
+class AspectUtilsKtTest {
+
+    @Test
+    fun `ProceedingJoinPoint-proceed should defer to trackSuccess on success`() {
+        // GIVEN
+        val joinPoint: ProceedingJoinPoint = mockk()
+        val trackSuccess: (JoinPoint) -> Unit = mockk(relaxed = true)
+        val trackError: (JoinPoint, Exception) -> Unit = mockk(relaxed = true)
+        val result = "indicating"
+
+        // SETUP
+        every { joinPoint.proceed() } returns result
+
+        // WHEN
+        val actual = joinPoint.proceed(trackSuccess, trackError)
+
+        // THEN
+        actual shouldBe result
+        verify { trackSuccess(joinPoint) }
+        verify(exactly = 0) { trackError(joinPoint, any()) }
+    }
+
+    @Test
+    fun `ProceedingJoinPoint-proceed should defer to trackError on error`() {
+        // GIVEN
+        val joinPoint: ProceedingJoinPoint = mockk()
+        val trackSuccess: (JoinPoint) -> Unit = mockk(relaxed = true)
+        val trackError: (JoinPoint, Exception) -> Unit = mockk(relaxed = true)
+        val error = RuntimeException("TEST")
+
+        // SETUP
+        every { joinPoint.proceed() } throws error
+
+        // WHEN
+        val actual = shouldThrowAny {
+            joinPoint.proceed(trackSuccess, trackError)
+        }
+
+        // THEN
+        actual shouldBe error
+        verify { trackError(joinPoint, error) }
+        verify(exactly = 0) { trackSuccess(joinPoint) }
+    }
+}

--- a/src/test/kotlin/fr/nicopico/n2rss/utils/HashingUtilsKtTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/utils/HashingUtilsKtTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 Nicolas PICON
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package fr.nicopico.n2rss.utils
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.Test
+
+class HashingUtilsKtTest {
+
+    @Test
+    fun `fingerprint can be created from a String`() {
+        // GIVEN
+        val secret = "Pulse exotic tray transmitted allowance calling lay"
+
+        // WHEN
+        val fingerprint = getFingerprint(secret)
+
+        // THEN
+        fingerprint shouldNotBe secret
+    }
+
+    @Test
+    fun `fingerprinting should fail gracefully`() {
+        // GIVEN
+        val secret = "Amanda calls biotechnology finances purchases thinkpad sampling"
+
+        // WHEN
+        val fingerprint = getFingerprint(secret, "unknown algorithm")
+
+        // THEN
+        fingerprint shouldBe null
+    }
+
+    @Test
+    fun `fingerprints should be consistent with their input`() {
+        // GIVEN
+        val secretA = "Abraham guinea difference dust government assistant entity"
+        val secretB = "Cos coating databases kruger satisfactory define kenny"
+
+        // WHEN
+        val fingerprintA1 = getFingerprint(secretA)
+        val fingerprintA2 = getFingerprint(secretA)
+        val fingerprintB1 = getFingerprint(secretB)
+        val fingerprintB2 = getFingerprint(secretB)
+
+        // THEN
+        fingerprintA1 shouldBe fingerprintA2
+        fingerprintB1 shouldBe fingerprintB2
+        fingerprintA1 shouldNotBe fingerprintB1
+    }
+}


### PR DESCRIPTION
Data collected for analytics :
- endpoints being accessed with the relevant parameters and the hash of the user-agent associated with the request 
- errors occurring in the endpoints and while parsing newsletter emails (the stacktraces are not collected)