### PR TITLE
fix: remove rss-code prefix from get-feed events

### DIFF
--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/simpleanalytics/SimpleAnalyticsEvent.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/simpleanalytics/SimpleAnalyticsEvent.kt
@@ -69,8 +69,7 @@ fun AnalyticsEvent.toSimpleAnalyticsEvent(
     )
     is AnalyticsEvent.GetFeed -> createSimpleAnalyticsEvent(
         simpleAnalyticsProperties,
-        // Add feed code to the event to get better reporting
-        event = AnalyticsCode.EVENT_GET_FEED + "-" + feedCode,
+        event = AnalyticsCode.EVENT_GET_FEED,
         metadata = mapOf(
             AnalyticsCode.DATA_FEED_CODE to feedCode
         )

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/simpleanalytics/SimpleAnalyticsEventTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/simpleanalytics/SimpleAnalyticsEventTest.kt
@@ -81,9 +81,7 @@ class SimpleAnalyticsEventTest {
                 ),
                 analyticsProperties,
                 createSimpleAnalyticsEvent(
-                    // Feed code should be appended to the event,
-                    // as metadata is not available for analysis in Simple Analytics
-                    AnalyticsCode.EVENT_GET_FEED + "-feed1",
+                    AnalyticsCode.EVENT_GET_FEED,
                     mapOf(
                         AnalyticsCode.DATA_FEED_CODE to "feed1"
                     )

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/simpleanalytics/SimpleAnalyticsServiceTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/simpleanalytics/SimpleAnalyticsServiceTest.kt
@@ -83,7 +83,7 @@ class SimpleAnalyticsServiceTest {
             body.readUtf8() should {
                 it shouldContain Regex("\"hostname\"\\s*:\"some-hostname\"")
                 it shouldContain Regex("\"ua\"\\s*:\"some-user-agent\"")
-                it shouldContain Regex("\"event\"\\s*:\"get-feed-rss-code\"")
+                it shouldContain Regex("\"event\"\\s*:\"get-feed\"")
                 it shouldContain Regex("\"feedCode\"\\s*:\"rss-code\"")
             }
         }


### PR DESCRIPTION
metadata is available in Simple Analytics and can be used in reporting