### PR TITLE
fix: Try to fix events not appearing on Simple Analytics

### DIFF
--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/simpleanalytics/SimpleAnalyticsEvent.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/simpleanalytics/SimpleAnalyticsEvent.kt
@@ -36,7 +36,7 @@ data class SimpleAnalyticsEvent(
     val metadata: Map<String, String>
 )
 
-@Suppress("LongMethod")
+@Suppress("LongMethod", "CyclomaticComplexMethod")
 fun AnalyticsEvent.toSimpleAnalyticsEvent(
     simpleAnalyticsProperties: N2RssProperties.SimpleAnalyticsProperties,
 ): SimpleAnalyticsEvent {

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/simpleanalytics/SimpleAnalyticsEvent.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/simpleanalytics/SimpleAnalyticsEvent.kt
@@ -15,13 +15,13 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
 package fr.nicopico.n2rss.analytics.simpleanalytics
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import fr.nicopico.n2rss.analytics.AnalyticsCode
 import fr.nicopico.n2rss.analytics.AnalyticsEvent
 import fr.nicopico.n2rss.config.N2RssProperties
+import fr.nicopico.n2rss.utils.getFingerprint
 
 data class SimpleAnalyticsEvent(
     @JsonProperty("type")
@@ -39,63 +39,92 @@ data class SimpleAnalyticsEvent(
 @Suppress("LongMethod")
 fun AnalyticsEvent.toSimpleAnalyticsEvent(
     simpleAnalyticsProperties: N2RssProperties.SimpleAnalyticsProperties,
-): SimpleAnalyticsEvent = when (this) {
-    is AnalyticsEvent.Error.EmailParsingError -> createSimpleAnalyticsEvent(
-        simpleAnalyticsProperties,
-        event = AnalyticsCode.EVENT_ERROR_PARSING,
-        metadata = mapOf(
-            AnalyticsCode.DATA_HANDLER_NAME to handlerName,
-            AnalyticsCode.DATA_EMAIL_TITLE to emailTitle
+): SimpleAnalyticsEvent {
+    fun String.fingerprint() = getFingerprint(this)
+
+    return when (this) {
+        is AnalyticsEvent.Error.EmailParsingError -> createSimpleAnalyticsEvent(
+            simpleAnalyticsProperties,
+            event = AnalyticsCode.EVENT_ERROR_PARSING,
+            metadata = mapOf(
+                AnalyticsCode.DATA_HANDLER_NAME to handlerName,
+                AnalyticsCode.DATA_EMAIL_TITLE to emailTitle
+            )
         )
-    )
-    is AnalyticsEvent.Error.GetFeedError -> createSimpleAnalyticsEvent(
-        simpleAnalyticsProperties,
-        event = AnalyticsCode.EVENT_ERROR_GET_FEED,
-        metadata = mapOf(
-            AnalyticsCode.DATA_FEED_CODE to feedCode
+
+        is AnalyticsEvent.Error.GetFeedError -> createSimpleAnalyticsEvent(
+            simpleAnalyticsProperties,
+            event = AnalyticsCode.EVENT_ERROR_GET_FEED,
+            metadata = mapOf(
+                AnalyticsCode.DATA_FEED_CODE to feedCode
+            )
         )
-    )
-    is AnalyticsEvent.Error.GetRssFeedsError -> createSimpleAnalyticsEvent(
-        simpleAnalyticsProperties,
-        event = AnalyticsCode.EVENT_ERROR_GET_RSS_FEEDS
-    )
-    is AnalyticsEvent.Error.HomeError -> createSimpleAnalyticsEvent(
-        simpleAnalyticsProperties,
-        event = AnalyticsCode.EVENT_ERROR_HOME
-    )
-    is AnalyticsEvent.Error.RequestNewsletterError -> createSimpleAnalyticsEvent(
-        simpleAnalyticsProperties,
-        event = AnalyticsCode.EVENT_ERROR_REQUEST_NEWSLETTER
-    )
-    is AnalyticsEvent.GetFeed -> createSimpleAnalyticsEvent(
-        simpleAnalyticsProperties,
-        event = AnalyticsCode.EVENT_GET_FEED,
-        metadata = mapOf(
-            AnalyticsCode.DATA_FEED_CODE to feedCode
+
+        is AnalyticsEvent.Error.GetRssFeedsError -> createSimpleAnalyticsEvent(
+            simpleAnalyticsProperties,
+            event = AnalyticsCode.EVENT_ERROR_GET_RSS_FEEDS
         )
-    )
-    is AnalyticsEvent.GetRssFeeds -> createSimpleAnalyticsEvent(
-        simpleAnalyticsProperties,
-        event = AnalyticsCode.EVENT_GET_RSS_FEEDS,
-    )
-    is AnalyticsEvent.Home -> createSimpleAnalyticsEvent(
-        simpleAnalyticsProperties,
-        event = AnalyticsCode.EVENT_HOME,
-    )
-    is AnalyticsEvent.NewRelease -> createSimpleAnalyticsEvent(
-        simpleAnalyticsProperties,
-        event = AnalyticsCode.EVENT_RELEASE,
-        metadata = mapOf(
-            AnalyticsCode.DATA_VERSION to version
+
+        is AnalyticsEvent.Error.HomeError -> createSimpleAnalyticsEvent(
+            simpleAnalyticsProperties,
+            event = AnalyticsCode.EVENT_ERROR_HOME
         )
-    )
-    is AnalyticsEvent.RequestNewsletter -> createSimpleAnalyticsEvent(
-        simpleAnalyticsProperties,
-        event = AnalyticsCode.EVENT_REQUEST_NEWSLETTER,
-        metadata = mapOf(
-            AnalyticsCode.DATA_NEWSLETTER_URL to newsletterUrl
+
+        is AnalyticsEvent.Error.RequestNewsletterError -> createSimpleAnalyticsEvent(
+            simpleAnalyticsProperties,
+            event = AnalyticsCode.EVENT_ERROR_REQUEST_NEWSLETTER
         )
-    )
+
+        is AnalyticsEvent.GetFeed -> createSimpleAnalyticsEvent(
+            simpleAnalyticsProperties,
+            event = AnalyticsCode.EVENT_GET_FEED,
+            metadata = buildMap {
+                put(AnalyticsCode.DATA_FEED_CODE, feedCode)
+                userAgent.fingerprint()?.let {
+                    put(AnalyticsCode.DATA_USER_AGENT, it)
+                }
+            }
+        )
+
+        is AnalyticsEvent.GetRssFeeds -> createSimpleAnalyticsEvent(
+            simpleAnalyticsProperties,
+            event = AnalyticsCode.EVENT_GET_RSS_FEEDS,
+            metadata = buildMap {
+                userAgent.fingerprint()?.let {
+                    put(AnalyticsCode.DATA_USER_AGENT, it)
+                }
+            }
+        )
+
+        is AnalyticsEvent.Home -> createSimpleAnalyticsEvent(
+            simpleAnalyticsProperties,
+            event = AnalyticsCode.EVENT_HOME,
+            metadata = buildMap {
+                userAgent.fingerprint()?.let {
+                    put(AnalyticsCode.DATA_USER_AGENT, it)
+                }
+            }
+        )
+
+        is AnalyticsEvent.NewRelease -> createSimpleAnalyticsEvent(
+            simpleAnalyticsProperties,
+            event = AnalyticsCode.EVENT_RELEASE,
+            metadata = mapOf(
+                AnalyticsCode.DATA_VERSION to version
+            )
+        )
+
+        is AnalyticsEvent.RequestNewsletter -> createSimpleAnalyticsEvent(
+            simpleAnalyticsProperties,
+            event = AnalyticsCode.EVENT_REQUEST_NEWSLETTER,
+            metadata = buildMap {
+                put(AnalyticsCode.DATA_NEWSLETTER_URL, newsletterUrl)
+                userAgent.fingerprint()?.let {
+                    put(AnalyticsCode.DATA_USER_AGENT, it)
+                }
+            }
+        )
+    }
 }
 
 private fun createSimpleAnalyticsEvent(

--- a/src/main/kotlin/fr/nicopico/n2rss/analytics/simpleanalytics/SimpleAnalyticsService.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/analytics/simpleanalytics/SimpleAnalyticsService.kt
@@ -63,8 +63,7 @@ class SimpleAnalyticsService(
                     .uri("/events")
                     .header(
                         "User-Agent",
-                        event.userAgent
-                            ?: simpleAnalyticsProperties.userAgent
+                        simpleAnalyticsProperties.userAgent
                     )
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(event.toSimpleAnalyticsEvent(simpleAnalyticsProperties))
@@ -75,20 +74,6 @@ class SimpleAnalyticsService(
             }
         }
     }
-
-    private val AnalyticsEvent.userAgent: String?
-        get() = when (this) {
-            is AnalyticsEvent.Home -> userAgent
-            is AnalyticsEvent.GetFeed -> userAgent
-            is AnalyticsEvent.GetRssFeeds -> userAgent
-            is AnalyticsEvent.RequestNewsletter -> userAgent
-            is AnalyticsEvent.NewRelease,
-            is AnalyticsEvent.Error.EmailParsingError,
-            is AnalyticsEvent.Error.GetFeedError,
-            is AnalyticsEvent.Error.GetRssFeedsError,
-            is AnalyticsEvent.Error.HomeError,
-            is AnalyticsEvent.Error.RequestNewsletterError -> null
-        }
 
     companion object {
         private val LOG = LoggerFactory.getLogger(SimpleAnalyticsService::class.java)

--- a/src/test/kotlin/fr/nicopico/n2rss/analytics/simpleanalytics/SimpleAnalyticsEventTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/analytics/simpleanalytics/SimpleAnalyticsEventTest.kt
@@ -21,6 +21,7 @@ package fr.nicopico.n2rss.analytics.simpleanalytics
 import fr.nicopico.n2rss.analytics.AnalyticsCode
 import fr.nicopico.n2rss.analytics.AnalyticsEvent
 import fr.nicopico.n2rss.config.N2RssProperties
+import fr.nicopico.n2rss.utils.getFingerprint
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -48,6 +49,8 @@ class SimpleAnalyticsEventTest {
             hostname = HOSTNAME,
         )
 
+        private val UA_FINGERPRINT = requireNotNull(getFingerprint(UA))
+
         private fun createSimpleAnalyticsEvent(
             event: String,
             metadata: Map<String, String> = emptyMap(),
@@ -71,7 +74,10 @@ class SimpleAnalyticsEventTest {
                 ),
                 analyticsProperties,
                 createSimpleAnalyticsEvent(
-                    AnalyticsCode.EVENT_HOME
+                    AnalyticsCode.EVENT_HOME,
+                    mapOf(
+                        AnalyticsCode.DATA_USER_AGENT to UA_FINGERPRINT,
+                    )
                 ),
             ),
             Arguments.of(
@@ -83,7 +89,8 @@ class SimpleAnalyticsEventTest {
                 createSimpleAnalyticsEvent(
                     AnalyticsCode.EVENT_GET_FEED,
                     mapOf(
-                        AnalyticsCode.DATA_FEED_CODE to "feed1"
+                        AnalyticsCode.DATA_FEED_CODE to "feed1",
+                        AnalyticsCode.DATA_USER_AGENT to UA_FINGERPRINT,
                     )
                 ),
             ),
@@ -96,7 +103,8 @@ class SimpleAnalyticsEventTest {
                 createSimpleAnalyticsEvent(
                     AnalyticsCode.EVENT_REQUEST_NEWSLETTER,
                     mapOf(
-                        AnalyticsCode.DATA_NEWSLETTER_URL to "url1"
+                        AnalyticsCode.DATA_NEWSLETTER_URL to "url1",
+                        AnalyticsCode.DATA_USER_AGENT to UA_FINGERPRINT,
                     )
                 ),
             ),
@@ -154,7 +162,10 @@ class SimpleAnalyticsEventTest {
                 ),
                 analyticsProperties,
                 createSimpleAnalyticsEvent(
-                    AnalyticsCode.EVENT_GET_RSS_FEEDS
+                    AnalyticsCode.EVENT_GET_RSS_FEEDS,
+                    mapOf(
+                        AnalyticsCode.DATA_USER_AGENT to UA_FINGERPRINT,
+                    )
                 ),
             ),
             Arguments.of(


### PR DESCRIPTION
The events do not appear on Simple Analytics after the 15/08, where version 2.7.0 was published.

It seems only events with the server user-agents are visible. 