### PR TITLE
feat: hidden newsletters

### DIFF
--- a/src/main/kotlin/fr/nicopico/n2rss/config/N2RssConfiguration.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/config/N2RssConfiguration.kt
@@ -76,6 +76,7 @@ constructor(
     data class FeedsProperties(
         val forceHttps: Boolean = true,
         val disabledNewsletters: List<String> = emptyList(),
+        val hiddenNewsletters: List<String> = emptyList(),
     )
     data class ReCaptchaProperties(
         val enabled: Boolean = true,

--- a/src/main/kotlin/fr/nicopico/n2rss/controller/home/HomeController.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/controller/home/HomeController.kt
@@ -57,7 +57,8 @@ class HomeController(
         @Suppress("UnusedParameter") /* Used by AnalyticsAspect */
         @RequestHeader(value = "User-Agent") userAgent: String,
     ): String {
-        val groupedNewsletterInfos: List<GroupedNewsletterInfo> = newsletterService.getEnabledNewslettersInfo()
+        val groupedNewsletterInfos: List<GroupedNewsletterInfo> = newsletterService
+            .getNonHiddenEnabledNewslettersInfo()
             .sortedBy { it.title }
             .filter { it.publicationCount > 0 }
             .groupBy { it.title.lowercase() }

--- a/src/main/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedController.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedController.kt
@@ -40,7 +40,7 @@ class RssFeedController(
         @Suppress("UnusedParameter") /* Used by AnalyticsAspect */
         @RequestHeader(value = "User-Agent") userAgent: String,
     ): List<NewsletterDTO> {
-        return newsletterService.getEnabledNewslettersInfo()
+        return newsletterService.getNonHiddenEnabledNewslettersInfo()
             .map { it.toDTO() }
     }
 

--- a/src/main/kotlin/fr/nicopico/n2rss/newsletter/data/NewsletterRepository.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/newsletter/data/NewsletterRepository.kt
@@ -17,6 +17,7 @@
  */
 package fr.nicopico.n2rss.newsletter.data
 
+import fr.nicopico.n2rss.config.N2RssProperties
 import fr.nicopico.n2rss.newsletter.NewsletterConfiguration
 import fr.nicopico.n2rss.newsletter.handlers.NewsletterHandler
 import fr.nicopico.n2rss.newsletter.handlers.newsletters
@@ -29,6 +30,7 @@ class NewsletterRepository(
     private val allNewsletterHandlers: List<NewsletterHandler>,
     @Qualifier(NewsletterConfiguration.ENABLED_NEWSLETTER_HANDLERS)
     private val enabledNewsletterHandlers: List<NewsletterHandler>,
+    private val feedsProperties: N2RssProperties.FeedsProperties,
 ) {
     fun findNewsletterByCode(code: String): Newsletter? {
         return allNewsletterHandlers
@@ -38,6 +40,12 @@ class NewsletterRepository(
 
     fun getEnabledNewsletters(): List<Newsletter> {
         return enabledNewsletterHandlers.flatMap { it.newsletters }
+    }
+
+    fun getNonHiddenEnabledNewsletters(): List<Newsletter> {
+        val hiddenNewsletters = feedsProperties.hiddenNewsletters
+        return getEnabledNewsletters()
+            .filter { it.code !in hiddenNewsletters }
     }
 
     fun getEnabledNewsletterHandlers(): List<NewsletterHandler> = enabledNewsletterHandlers

--- a/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/NewsletterService.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/NewsletterService.kt
@@ -31,17 +31,6 @@ class NewsletterService(
     private val publicationService: PublicationService,
 ) {
     /**
-     * Retrieves information on all enabled newsletters.
-     *
-     * @return a list of `NewsletterInfo` objects containing details about each enabled newsletter.
-     */
-    fun getEnabledNewslettersInfo(): List<NewsletterInfo> {
-        return newsletterRepository
-            .getEnabledNewsletters()
-            .map { createNewsletterInfo(it) }
-    }
-
-    /**
      * Retrieves information on all enabled newsletters that are not hidden.
      *
      * @return a list of `NewsletterInfo` objects containing details about each non-hidden enabled newsletter.

--- a/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/NewsletterService.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/NewsletterService.kt
@@ -38,16 +38,29 @@ class NewsletterService(
     fun getEnabledNewslettersInfo(): List<NewsletterInfo> {
         return newsletterRepository
             .getEnabledNewsletters()
-            .map {
-                NewsletterInfo(
-                    code = it.code,
-                    title = it.name,
-                    websiteUrl = it.websiteUrl,
-                    publicationCount = publicationService.getPublicationsCount(it),
-                    startingDate = publicationService.getOldestPublicationDate(it),
-                    notes = it.notes,
-                )
-            }
+            .map { createNewsletterInfo(it) }
+    }
+
+    /**
+     * Retrieves information on all enabled newsletters that are not hidden.
+     *
+     * @return a list of `NewsletterInfo` objects containing details about each non-hidden enabled newsletter.
+     */
+    fun getNonHiddenEnabledNewslettersInfo(): List<NewsletterInfo> {
+        return newsletterRepository
+            .getNonHiddenEnabledNewsletters()
+            .map { createNewsletterInfo(it) }
+    }
+
+    private fun createNewsletterInfo(newsletter: Newsletter): NewsletterInfo {
+        return NewsletterInfo(
+            code = newsletter.code,
+            title = newsletter.name,
+            websiteUrl = newsletter.websiteUrl,
+            publicationCount = publicationService.getPublicationsCount(newsletter),
+            startingDate = publicationService.getOldestPublicationDate(newsletter),
+            notes = newsletter.notes,
+        )
     }
 
     /**

--- a/src/test/kotlin/fr/nicopico/n2rss/controller/home/HomeControllerTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/controller/home/HomeControllerTest.kt
@@ -114,7 +114,7 @@ class HomeControllerTest {
                 newsletterD,
                 newsletterB,
             )
-            every { newsletterService.getEnabledNewslettersInfo() } returns newslettersInfo
+            every { newsletterService.getNonHiddenEnabledNewslettersInfo() } returns newslettersInfo
             every { feedsProperties.forceHttps } returns false
 
             val requestUrl = StringBuffer("http://localhost:8134")
@@ -184,7 +184,7 @@ class HomeControllerTest {
                 newsletterA3,
                 newsletterB,
             )
-            every { newsletterService.getEnabledNewslettersInfo() } returns newslettersInfo
+            every { newsletterService.getNonHiddenEnabledNewslettersInfo() } returns newslettersInfo
             every { feedsProperties.forceHttps } returns false
 
             val requestUrl = StringBuffer("http://localhost:8134")
@@ -216,7 +216,7 @@ class HomeControllerTest {
         fun `home should use HTTPS feed when the feature is activated`() {
             // GIVEN
             val newslettersInfo = listOf<NewsletterInfo>()
-            every { newsletterService.getEnabledNewslettersInfo() } returns newslettersInfo
+            every { newsletterService.getNonHiddenEnabledNewslettersInfo() } returns newslettersInfo
             every { feedsProperties.forceHttps } returns true
 
             val requestUrl = StringBuffer("http://localhost:8134")

--- a/src/test/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedControllerTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/controller/rss/RssFeedControllerTest.kt
@@ -59,7 +59,7 @@ class RssFeedControllerTest {
     @Test
     fun `getRssFeeds should returns info on all the current feeds`() {
         // GIVEN
-        every { newsletterService.getEnabledNewslettersInfo() } returns List(2) {
+        every { newsletterService.getNonHiddenEnabledNewslettersInfo() } returns List(2) {
             NewsletterInfo(
                 code = "newsletter_$it",
                 title = "Newsletter$it",

--- a/src/test/kotlin/fr/nicopico/n2rss/newsletter/service/NewsletterServiceTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/newsletter/service/NewsletterServiceTest.kt
@@ -58,7 +58,7 @@ class NewsletterServiceTest {
     }
 
     @Test
-    fun `should give info about all supported newsletters`() {
+    fun `should give info about enabled non-hidden newsletters`() {
         // GIVEN
         val firstPublicationCode1 = LocalDate(2022, 3, 21)
         val firstPublicationCode2 = LocalDate(2023, 7, 8)
@@ -77,10 +77,10 @@ class NewsletterServiceTest {
                 else -> null
             }
         }
-        every { newsletterRepository.getEnabledNewsletters() } returns newsletters
+        every { newsletterRepository.getNonHiddenEnabledNewsletters() } returns newsletters
 
         // WHEN
-        val result = newsletterService.getEnabledNewslettersInfo()
+        val result = newsletterService.getNonHiddenEnabledNewslettersInfo()
 
         // WHEN
         result shouldContainOnly listOf(


### PR DESCRIPTION
Add a configuration property to keep a newsletter enabled without making it visible on the front-end. This will allow beta-testing RSS feeds without making it public 