### PR TITLE
feat: save resolved article urls in database

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,6 +114,7 @@ dependencies {
     implementation(libs.jacksonModuleKotlin)
     implementation(libs.kotlin.reflect)
     implementation(libs.kotlinx.datetime)
+    implementation(libs.kotlinx.coroutines)
     implementation(libs.jakartaMail)
     implementation(libs.jsoup)
     implementation(libs.rome)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ junitJupiterEngine = "5.11.4"
 kotestAssertions = "5.9.1"
 kotestKotlinxDatetime = "1.1.0"
 kotlin = "2.1.20"
+kotlinxCoroutines = "1.10.2"
 kotlinxDatetime = "0.6.2"
 kover = "0.9.1"
 mockk = "1.14.0"
@@ -23,6 +24,7 @@ springMock = "4.0.2"
 [libraries]
 # Kotlin
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "kotlinxCoroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 
 # Spring Boot Starters

--- a/src/main/kotlin/fr/nicopico/n2rss/newsletter/data/ArticleRepository.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/newsletter/data/ArticleRepository.kt
@@ -15,38 +15,15 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-package fr.nicopico.n2rss.newsletter.data.entity
+package fr.nicopico.n2rss.newsletter.data
 
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.Lob
-import jakarta.persistence.ManyToOne
+import fr.nicopico.n2rss.newsletter.data.entity.ArticleEntity
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 
-@Entity(name = "ARTICLES")
-data class ArticleEntity(
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
-
-    @Column(nullable = false)
-    val title: String,
-
-    @Column(nullable = false, length = 2000)
-    val link: String,
-
-    @Column(nullable = true, length = 2000)
-    val resolvedLink: String? = null,
-
-    @Column(nullable = false, length = 5000)
-    @Lob
-    val description: String,
-
-    @ManyToOne
-    @JoinColumn(name = "publication_id", nullable = false)
-    val publication: PublicationEntity,
-)
+@Repository
+interface ArticleRepository : JpaRepository<ArticleEntity, Long> {
+    fun findByResolvedLinkIsNull(pageable: Pageable): Page<ArticleEntity>
+}

--- a/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/ArticleService.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/ArticleService.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 Nicolas PICON
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package fr.nicopico.n2rss.newsletter.service
+
+import fr.nicopico.n2rss.newsletter.data.ArticleRepository
+import fr.nicopico.n2rss.utils.url.resolveUris
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.net.URI
+import java.util.concurrent.TimeUnit
+
+private const val ARTICLE_RESOLVE_URI_BATCH_SIZE = 15
+
+@Service
+class ArticleService(
+    private val articleRepository: ArticleRepository,
+) {
+    @Scheduled(fixedDelay = 15, timeUnit = TimeUnit.MINUTES, initialDelay = 1)
+    @Transactional
+    fun saveResolvedUrls() {
+        val pageable = PageRequest.ofSize(ARTICLE_RESOLVE_URI_BATCH_SIZE)
+        val articles = articleRepository.findByResolvedLinkIsNull(pageable)
+            .content
+            .toMutableList()
+        LOG.debug("Resolving urls for ${articles.size} articles...")
+
+        val resolvedUris = runBlocking {
+            resolveUris(articles.map { URI(it.link) })
+        }
+
+        articles.toMutableList()
+            .replaceAll { article ->
+                article.copy(
+                    resolvedLink = resolvedUris[URI(article.link)]?.toString() ?: article.link,
+                )
+            }
+        articleRepository.saveAll(articles)
+        LOG.debug("Resolving urls done!")
+    }
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(ArticleService::class.java)
+    }
+}

--- a/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/ArticleService.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/ArticleService.kt
@@ -47,14 +47,13 @@ class ArticleService(
             resolveUris(articles.map { URI(it.link) })
         }
 
-        articles.toMutableList()
-            .replaceAll { article ->
-                article.copy(
-                    resolvedLink = resolvedUris[URI(article.link)]?.toString() ?: article.link,
-                )
-            }
+        articles.replaceAll { article ->
+            article.copy(
+                resolvedLink = resolvedUris[URI(article.link)]?.toString() ?: article.link,
+            )
+        }
         articleRepository.saveAll(articles)
-        LOG.debug("Resolving urls done!")
+        LOG.debug("Saved resolved url for articles {}", articles.map { it.title })
     }
 
     companion object {

--- a/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/PublicationService.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/PublicationService.kt
@@ -97,6 +97,7 @@ class PublicationService(
                     ArticleEntity(
                         title = article.title,
                         link = article.link.toString(),
+                        resolvedLink = null,
                         description = article.description,
                         publication = entity,
                     )

--- a/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/PublicationService.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/PublicationService.kt
@@ -97,7 +97,6 @@ class PublicationService(
                     ArticleEntity(
                         title = article.title,
                         link = article.link.toString(),
-                        resolvedLink = null,
                         description = article.description,
                         publication = entity,
                     )

--- a/src/main/kotlin/fr/nicopico/n2rss/utils/url/RestClientExt.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/utils/url/RestClientExt.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 Nicolas PICON
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package fr.nicopico.n2rss.utils.url
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.springframework.http.HttpStatus
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.web.client.RestClient
+import java.net.HttpURLConnection
+import java.net.URI
+import kotlin.coroutines.resume
+
+private const val TIMEOUT_MS = 5000
+
+suspend fun resolveUris(
+    urls: List<URI>,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    maxConcurrency: Int = 5,
+): Map<URI, URI> {
+    val restClient = RestClient.builder()
+        .requestFactory(
+            object : SimpleClientHttpRequestFactory() {
+                override fun prepareConnection(connection: HttpURLConnection, httpMethod: String) {
+                    super.prepareConnection(connection, httpMethod)
+                    connection.instanceFollowRedirects = false
+                    connection.connectTimeout = TIMEOUT_MS
+                    connection.readTimeout = TIMEOUT_MS
+                }
+            }
+        )
+        .build()
+
+    return withContext(dispatcher) {
+        urls.chunked(maxConcurrency)
+            .flatMap { urlChunk ->
+                val resolvedUrls = urlChunk.associateWith {
+                    withTimeout(TIMEOUT_MS.toLong()) {
+                        restClient.resolveUrl(it)
+                    }
+                }
+                resolvedUrls.values.awaitAll()
+                resolvedUrls.entries
+            }
+            .associate {
+                it.key to it.value.await()
+            }
+    }
+}
+
+private val REDIRECT_STATUS_CODES = listOf(
+    HttpStatus.MOVED_PERMANENTLY,
+    HttpStatus.FOUND,
+    HttpStatus.TEMPORARY_REDIRECT,
+    HttpStatus.PERMANENT_REDIRECT,
+)
+
+private suspend fun RestClient.resolveUrl(originalUri: URI): Deferred<URI> = coroutineScope {
+    async {
+        suspendCancellableCoroutine {
+            val response = get().uri(originalUri).retrieve().toBodilessEntity()
+
+            val resolvedUri = if (response.statusCode in REDIRECT_STATUS_CODES) {
+                response.headers.location
+            } else null
+
+            it.resume(resolvedUri ?: originalUri)
+        }.let { resolvedUri ->
+            // Handle multiple redirects
+            if (resolvedUri != originalUri) {
+                resolveUrl(resolvedUri).await()
+            } else resolvedUri
+        }
+    }
+}

--- a/src/main/kotlin/fr/nicopico/n2rss/utils/url/RestClientExt.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/utils/url/RestClientExt.kt
@@ -51,6 +51,10 @@ suspend fun resolveUris(
                 }
             }
         )
+        .defaultStatusHandler {
+            // Ignore HTTP errors
+            true
+        }
         .build()
 
     return withContext(dispatcher) {

--- a/src/main/resources/db/migration/V4__.sql
+++ b/src/main/resources/db/migration/V4__.sql
@@ -15,38 +15,6 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-package fr.nicopico.n2rss.newsletter.data.entity
 
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.Lob
-import jakarta.persistence.ManyToOne
-
-@Entity(name = "ARTICLES")
-class ArticleEntity(
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
-
-    @Column(nullable = false)
-    val title: String,
-
-    @Column(nullable = false, length = 2000)
-    val link: String,
-
-    @Column(nullable = true, length = 2000)
-    val resolvedLink: String? = null,
-
-    @Column(nullable = false, length = 5000)
-    @Lob
-    val description: String,
-
-    @ManyToOne
-    @JoinColumn(name = "publication_id", nullable = false)
-    val publication: PublicationEntity,
-)
+ALTER TABLE articles
+    ADD resolved_link VARCHAR(2000) NULL;

--- a/src/test/kotlin/fr/nicopico/n2rss/utils/url/RestClientExtKtTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/utils/url/RestClientExtKtTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Nicolas PICON
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package fr.nicopico.n2rss.utils.url
+
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+class RestClientExtKtTest {
+
+    @Test
+    fun `should resolve an URI with 302 redirect`() {
+        val newsletterUri: URI = URI.create(
+            "https://f6p7au8ab.cc.rs6.net/tn.jsp?f=001DOzVYeoi_U8vAlnJAn9bZ-QTgRI4Civmiz1NoNpWDzi1oKjl0VNGULdyb96qdfHWspriSkrhat5m9DQax_Jk849PRYhVw7RmNYbvio2HCsW0H-35rJWcu7j1ItF4Rl0FOkjNKMyjGmRbbCmhi-Ec0QDlnSqGVte5dlxLLqVW9bc1vdCQ3qtZeoqOvvX5y8qFTXfjl-4DagA=&c=Q9c5o8mt_8OViXlfmsJkqA6CorbOewgTT4JDqd720cnkPFc8CUj-WA==&ch=7Dq-GqBxSzH5npeoV9hdFigIdzmKY1iDKFdziUVFscR07n774bwUUw=="
+        )
+        val resolvedUri = URI.create("https://carrion.dev/en/posts/context-parameters-kotlin/")
+
+        val result = runBlocking {
+            resolveUris(listOf(newsletterUri))
+        }
+
+        result shouldBe mapOf(newsletterUri to resolvedUri)
+    }
+}


### PR DESCRIPTION
This change will retrieve the final article URL, after the redirect triggered by the URL provided by the newsletter. 

This URL can be used for data analysis and to detect duplicates. 
RSS feeds will still rely on the URL provided by the newsletters to ensure newsletter providers receive their analytics.