### PR TITLE
chore: improve URL resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 HELP.md
 .gradle
+.kotlin
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/deploy/application.properties
+++ b/deploy/application.properties
@@ -46,4 +46,6 @@ n2rss.github.repository=n2rss
 n2rss.github.access-token=${N2RSS_GITHUB_ACCESS_TOKEN}
 n2rss.github.monitoring-enabled=true
 n2rss.persistenceMode=${N2RSS_PERSISTENCE_MODE}
+
 n2rss.external.base-url=${N2RSS_BASE_URL}
+n2rss.external.resolve-article-urls=${N2RSS_RESOLVE_ARTICLE_URLS}

--- a/src/main/kotlin/fr/nicopico/n2rss/config/N2RssConfiguration.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/config/N2RssConfiguration.kt
@@ -112,5 +112,6 @@ constructor(
     )
     data class ExternalProperties(
         val baseUrl: URL,
+        val resolveArticleUrls: Boolean = false,
     )
 }

--- a/src/main/kotlin/fr/nicopico/n2rss/config/N2RssConfiguration.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/config/N2RssConfiguration.kt
@@ -113,5 +113,6 @@ constructor(
     data class ExternalProperties(
         val baseUrl: URL,
         val resolveArticleUrls: Boolean = false,
+        val userAgent: String = "n2rss",
     )
 }

--- a/src/main/kotlin/fr/nicopico/n2rss/controller/maintenance/LocalOnlyController.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/controller/maintenance/LocalOnlyController.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Nicolas PICON
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package fr.nicopico.n2rss.controller.maintenance
+
+import fr.nicopico.n2rss.newsletter.service.ArticleService
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+
+/**
+ * Controller for API endpoints that should only be available for developers.
+ * Those endpoints will not be available in production.
+ */
+@Profile("local")
+@Controller
+class LocalOnlyController(
+    private val articleService: ArticleService,
+) {
+    @GetMapping("/resolveArticleUrls")
+    fun resolveArticleUrls(response: HttpServletResponse) {
+        articleService.resolveSomeArticleUrls()
+
+        response.status = HttpServletResponse.SC_OK
+        response.writer.write("Batch processed finished!")
+    }
+}

--- a/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/ArticleService.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/ArticleService.kt
@@ -17,26 +17,38 @@
  */
 package fr.nicopico.n2rss.newsletter.service
 
+import fr.nicopico.n2rss.config.N2RssProperties
 import fr.nicopico.n2rss.newsletter.data.ArticleRepository
 import fr.nicopico.n2rss.utils.url.resolveUris
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.net.URI
+import java.util.concurrent.TimeUnit
 
 private const val ARTICLE_RESOLVE_URI_BATCH_SIZE = 15
 
 @Service
 class ArticleService(
     private val articleRepository: ArticleRepository,
+    private val externalProperties: N2RssProperties.ExternalProperties,
 ) {
-    // Disabled temporarily
-    //@Scheduled(fixedDelay = 15, timeUnit = TimeUnit.MINUTES, initialDelay = 1)
-    @Suppress("unused")
+    @Scheduled(fixedDelay = 15, timeUnit = TimeUnit.MINUTES, initialDelay = 1)
     @Transactional
-    fun saveResolvedUrls() {
+    fun scheduledArticleUrlResolution() {
+        if (!externalProperties.resolveArticleUrls) {
+            LOG.debug("Article URL resolution is disabled")
+            return
+        }
+
+        resolveSomeArticleUrls()
+    }
+
+    @Transactional
+    fun resolveSomeArticleUrls() {
         val pageable = PageRequest.ofSize(ARTICLE_RESOLVE_URI_BATCH_SIZE)
         val articles = articleRepository.findByResolvedLinkIsNull(pageable)
             .content
@@ -49,6 +61,7 @@ class ArticleService(
 
         articles.replaceAll { article ->
             article.copy(
+                // TODO Indicate fails resolved links
                 resolvedLink = resolvedUris[URI(article.link)]?.toString() ?: article.link,
             )
         }

--- a/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/ArticleService.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/ArticleService.kt
@@ -61,8 +61,8 @@ class ArticleService(
 
         articles.replaceAll { article ->
             article.copy(
-                // TODO Indicate fails resolved links
-                resolvedLink = resolvedUris[URI(article.link)]?.toString() ?: article.link,
+                resolvedLink = resolvedUris[URI(article.link)]?.toString()
+                    ?: FAILED_URL_RESOLUTION_PLACEHOLDER,
             )
         }
         articleRepository.saveAll(articles)
@@ -71,5 +71,7 @@ class ArticleService(
 
     companion object {
         private val LOG = LoggerFactory.getLogger(ArticleService::class.java)
+
+        const val FAILED_URL_RESOLUTION_PLACEHOLDER = "-"
     }
 }

--- a/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/ArticleService.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/ArticleService.kt
@@ -56,7 +56,7 @@ class ArticleService(
         LOG.debug("Resolving urls for ${articles.size} articles...")
 
         val resolvedUris = runBlocking {
-            resolveUris(articles.map { URI(it.link) })
+            resolveUris(externalProperties.userAgent, articles.map { URI(it.link) })
         }
 
         articles.replaceAll { article ->

--- a/src/main/kotlin/fr/nicopico/n2rss/utils/url/RestClientExt.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/utils/url/RestClientExt.kt
@@ -38,9 +38,6 @@ import kotlin.coroutines.resume
 private const val TIMEOUT_MS = 5000
 private val LOG = LoggerFactory.getLogger("RestClientExt")
 
-// FIXME URL resolution does not work for "beehiiv" URLs
-//  ex: https://link.mail.beehiiv.com/ss/c/u001.3a5P_SwQzY5x8USD2q4p0r7tZ4Xc_IMfzOhNH-sZPqXF5edqv_aYXhBXdCzcRVykDyq9Wl9a1Ge1hLkoeCwntpQkvfL-5h3Xz0oMO0MNUb4JOZkpL15kAwrX55aT-RUjLDbPVBr78sxN0T17LYZS4Ar3QuxRWfDySw2dWCyJIvNwmllgb9FqevhlQtIWQwJomy11i66WPmIY76Tj39FzlimpG3Ylm2Ay4QNS_wmQzYhLJrM85OjSu_-5vq3RR7SolPqm7MhUq_R5Y3pn_KLdo_cS7p1n9gckSSXS1rLk9LH9PWAEdKGOPayosqQ2YCNR/4bo/zbVYybWiRwSiQr1bey4J-w/h10/h001.2nd4OWD1oRoMgzUpVtSORAo4DI3VH1mAH-36d0sUrRg
-//  -> https://www.qawolf.com/webinars/ai-prompt-evaluations-beyond-golden-datasets
 suspend fun resolveUris(
     userAgent: String,
     urls: List<URI>,
@@ -64,11 +61,12 @@ suspend fun resolveUris(
     return withContext(dispatcher) {
         urls.chunked(maxConcurrency)
             .flatMap { urlChunk ->
-                val resolvedUrls = urlChunk.associateWith {
-                    withTimeout(TIMEOUT_MS.toLong()) {
-                        restClient.resolveUrl(it)
+                val resolvedUrls = urlChunk
+                    .associateWith { articleURI ->
+                        withTimeout(TIMEOUT_MS.toLong()) {
+                            restClient.resolveUrl(articleURI)
+                        }
                     }
-                }
                 resolvedUrls.values.awaitAll()
                 resolvedUrls.entries
             }
@@ -88,6 +86,14 @@ private val REDIRECT_STATUS_CODES = listOf(
 private suspend fun RestClient.resolveUrl(originalUri: URI): Deferred<URI?> = coroutineScope {
     async {
         suspendCancellableCoroutine {
+            // TODO Add support for beehiiv URLs
+            if (originalUri.host == "link.mail.beehiiv.com") {
+                // beehiiv URLs are not yet supported
+                it.resume(null)
+                return@suspendCancellableCoroutine
+            }
+
+            // Call HTTP to resolve the URL
             val response = get()
                 .uri(originalUri)
                 .retrieve()

--- a/src/main/kotlin/fr/nicopico/n2rss/utils/url/RestClientExt.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/utils/url/RestClientExt.kt
@@ -37,6 +37,9 @@ import kotlin.coroutines.resume
 private const val TIMEOUT_MS = 5000
 private val LOG = LoggerFactory.getLogger("RestClientExt")
 
+// FIXME URL resolution does not work for "beehiiv" URLs
+//  ex: https://link.mail.beehiiv.com/ss/c/u001.3a5P_SwQzY5x8USD2q4p0r7tZ4Xc_IMfzOhNH-sZPqXF5edqv_aYXhBXdCzcRVykDyq9Wl9a1Ge1hLkoeCwntpQkvfL-5h3Xz0oMO0MNUb4JOZkpL15kAwrX55aT-RUjLDbPVBr78sxN0T17LYZS4Ar3QuxRWfDySw2dWCyJIvNwmllgb9FqevhlQtIWQwJomy11i66WPmIY76Tj39FzlimpG3Ylm2Ay4QNS_wmQzYhLJrM85OjSu_-5vq3RR7SolPqm7MhUq_R5Y3pn_KLdo_cS7p1n9gckSSXS1rLk9LH9PWAEdKGOPayosqQ2YCNR/4bo/zbVYybWiRwSiQr1bey4J-w/h10/h001.2nd4OWD1oRoMgzUpVtSORAo4DI3VH1mAH-36d0sUrRg
+//  -> https://www.qawolf.com/webinars/ai-prompt-evaluations-beyond-golden-datasets
 suspend fun resolveUris(
     urls: List<URI>,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,

--- a/src/main/kotlin/fr/nicopico/n2rss/utils/url/RestClientExt.kt
+++ b/src/main/kotlin/fr/nicopico/n2rss/utils/url/RestClientExt.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.web.client.RestClient
@@ -41,11 +42,13 @@ private val LOG = LoggerFactory.getLogger("RestClientExt")
 //  ex: https://link.mail.beehiiv.com/ss/c/u001.3a5P_SwQzY5x8USD2q4p0r7tZ4Xc_IMfzOhNH-sZPqXF5edqv_aYXhBXdCzcRVykDyq9Wl9a1Ge1hLkoeCwntpQkvfL-5h3Xz0oMO0MNUb4JOZkpL15kAwrX55aT-RUjLDbPVBr78sxN0T17LYZS4Ar3QuxRWfDySw2dWCyJIvNwmllgb9FqevhlQtIWQwJomy11i66WPmIY76Tj39FzlimpG3Ylm2Ay4QNS_wmQzYhLJrM85OjSu_-5vq3RR7SolPqm7MhUq_R5Y3pn_KLdo_cS7p1n9gckSSXS1rLk9LH9PWAEdKGOPayosqQ2YCNR/4bo/zbVYybWiRwSiQr1bey4J-w/h10/h001.2nd4OWD1oRoMgzUpVtSORAo4DI3VH1mAH-36d0sUrRg
 //  -> https://www.qawolf.com/webinars/ai-prompt-evaluations-beyond-golden-datasets
 suspend fun resolveUris(
+    userAgent: String,
     urls: List<URI>,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
     maxConcurrency: Int = 5,
 ): Map<URI, URI?> {
     val restClient = RestClient.builder()
+        .defaultHeader(HttpHeaders.USER_AGENT, userAgent)
         .requestFactory(
             object : SimpleClientHttpRequestFactory() {
                 override fun prepareConnection(connection: HttpURLConnection, httpMethod: String) {

--- a/src/test/kotlin/fr/nicopico/n2rss/N2RssApplicationTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/N2RssApplicationTest.kt
@@ -63,6 +63,7 @@ class N2RssApplicationProdTest {
             registry.add("N2RSS_ANALYTICS_UA") { "<user-agent>" }
 
             registry.add("N2RSS_BASE_URL") { "https://n2rss.nicopico.fr" }
+            registry.add("N2RSS_RESOLVE_ARTICLE_URLS") { "true" }
 
             registry.add("N2RSS_DATABASE_PASSWORD") { "" }
             registry.add("N2RSS_DATABASE_SCHEMA") { "PUBLIC" }

--- a/src/test/kotlin/fr/nicopico/n2rss/utils/url/RestClientExtKtTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/utils/url/RestClientExtKtTest.kt
@@ -42,6 +42,8 @@ class RestClientExtKtTest {
 
     @Test
     fun `should resolve an URI with 302 redirect`() {
+        // GIVEN
+        val userAgent = "UA"
         val resolvedUrl = server.url("/redirect/url")
         server.enqueue(
             // Redirect
@@ -57,19 +59,23 @@ class RestClientExtKtTest {
 
         val originalUri: URI = server.url("/original/url").toUri()
 
+        // WHEN
         val result = runBlocking {
-            resolveUris(listOf(originalUri))
+            resolveUris(userAgent, listOf(originalUri))
         }
 
+        // THEN
         result shouldBe mapOf(originalUri to resolvedUrl.toUri())
     }
 
     @Test
     fun `should follow multiple redirects to resolve an URI`() {
+        // GIVEN
+        val userAgent = "UA"
         val originalUri: URI = server.url("/original/url").toUri()
         val resolvedUri: URI = server.url("/redirect2").toUri()
 
-        // Represent "beehiiv" redirection behavior
+        // follow "beehiiv" redirection behavior
         // 302 Found
         server.enqueue(
             MockResponse()
@@ -89,15 +95,19 @@ class RestClientExtKtTest {
                 .setResponseCode(304)
         )
 
+        // WHEN
         val result = runBlocking {
-            resolveUris(listOf(originalUri))
+            resolveUris(userAgent, listOf(originalUri))
         }
 
+        // THEN
         result shouldBe mapOf(originalUri to resolvedUri)
     }
 
     @Test
     fun `should map to null if the original URI if not accessible`() {
+        // GIVEN
+        val userAgent = "UA"
         server.enqueue(
             // Error 403 Forbidden
             MockResponse().setResponseCode(403)
@@ -105,10 +115,12 @@ class RestClientExtKtTest {
 
         val originalUri: URI = server.url("/original/url").toUri()
 
+        // WHEN
         val result = runBlocking {
-            resolveUris(listOf(originalUri))
+            resolveUris(userAgent, listOf(originalUri))
         }
 
+        // THEN
         result shouldBe mapOf(originalUri to null)
     }
 }

--- a/src/test/kotlin/fr/nicopico/n2rss/utils/url/RestClientExtKtTest.kt
+++ b/src/test/kotlin/fr/nicopico/n2rss/utils/url/RestClientExtKtTest.kt
@@ -23,6 +23,7 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.net.URI
 
@@ -122,5 +123,20 @@ class RestClientExtKtTest {
 
         // THEN
         result shouldBe mapOf(originalUri to null)
+    }
+
+    @Disabled
+    @Test
+    fun `should resolve 'beehiiv' urls`() {
+        val userAgent = "n2rss"
+        val beehiivUrl =
+            URI("https://link.mail.beehiiv.com/ss/c/u001.3a5P_SwQzY5x8USD2q4p0r7tZ4Xc_IMfzOhNH-sZPqXF5edqv_aYXhBXdCzcRVykDyq9Wl9a1Ge1hLkoeCwntpQkvfL-5h3Xz0oMO0MNUb4JOZkpL15kAwrX55aT-RUjLDbPVBr78sxN0T17LYZS4Ar3QuxRWfDySw2dWCyJIvNwmllgb9FqevhlQtIWQwJomy11i66WPmIY76Tj39FzlimpG3Ylm2Ay4QNS_wmQzYhLJrM85OjSu_-5vq3RR7SolPqm7MhUq_R5Y3pn_KLdo_cS7p1n9gckSSXS1rLk9LH9PWAEdKGOPayosqQ2YCNR/4bo/zbVYybWiRwSiQr1bey4J-w/h10/h001.2nd4OWD1oRoMgzUpVtSORAo4DI3VH1mAH-36d0sUrRg")
+        val expectedUrl = URI("https://www.qawolf.com/webinars/ai-prompt-evaluations-beyond-golden-datasets")
+
+        val result = runBlocking {
+            resolveUris(userAgent, listOf(beehiivUrl))
+        }
+
+        result[beehiivUrl] shouldBe expectedUrl
     }
 }


### PR DESCRIPTION
- disable automatic URL resolution in DEV environment. A DEV-only endpoint is available to trigger the resolution manually
- mark URL resolution failure with a "-" in the database
- disable URL resolution for beehiiv links (unsupported JavaScript redirection). These will be marked as a resolution failure when encountered
- configure a user-agent for URL resolution