### PR TITLE
fix: ensure emails are processed only once

### DIFF
--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/EmailChecker.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/EmailChecker.kt
@@ -126,6 +126,7 @@ class EmailChecker(
             session.moveToProcessed(processedEmails)
         } catch (e: Exception) {
             LOG.warn("Error while moving processed emails to specified folder", e)
+            monitoringService.notifyGenericError(e, context = "Moving emails to specified folder")
         }
     }
 }

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/EmailChecker.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/EmailChecker.kt
@@ -50,23 +50,33 @@ class EmailChecker(
             val emails = emailClient.checkEmails()
             LOG.info("{} emails found, processing...", emails.size)
 
+            val processedEmails = mutableListOf<Email>()
+
             for (email in emails) {
-                processEmail(email)
+                if (processEmail(email)) {
+                    processedEmails.add(email)
+                }
             }
 
             LOG.info("Processing done!")
+
+            if (moveAfterProcessingEnabled) {
+                LOG.debug("Move processed emails to specified folder")
+                moveAllProcessedEmails(processedEmails)
+            }
+
         } catch (e: Exception) {
             LOG.error("Error while checking emails", e)
             monitoringService.notifyGenericError(e, context = "Checking emails")
         }
     }
 
-    @Suppress("TooGenericExceptionCaught", "NestedBlockDepth")
-    private fun processEmail(email: Email) {
+    @Suppress("TooGenericExceptionCaught", "NestedBlockDepth", "ReturnCount")
+    private fun processEmail(email: Email): Boolean {
         var newsletterHandler: NewsletterHandler? = null
         try {
             newsletterHandler = newsletterService.findNewsletterHandlerForEmail(email)
-                ?: return
+                ?: return false
 
             LOG.info("\"{}\" is being processed by {}", email.subject, newsletterHandler::class.java)
             val publications = newsletterHandler.process(email)
@@ -81,16 +91,7 @@ class EmailChecker(
             try {
                 LOG.info("\"{}\" processing done, marking email as read", email.subject)
                 emailClient.markAsRead(email)
-                if (moveAfterProcessingEnabled) {
-                    LOG.debug("Move \"{}\" to processed folder", email.subject)
-                    try {
-                        emailClient.moveToProcessed(email)
-                    } catch (e: Exception) {
-                        LOG.error("Error while moving email {} to processed", email.subject, e)
-                        monitoringService
-                            .notifyGenericError(e, context = "Moving email '${email.subject}' to processed folder")
-                    }
-                }
+                return true
             } catch (e: Exception) {
                 LOG.error("Error while marking email {} as processed", email.subject, e)
                 monitoringService.notifyGenericError(e, context = "Marking email '${email.subject}' as processed")
@@ -98,6 +99,19 @@ class EmailChecker(
         } catch (e: Exception) {
             LOG.error("Error processing email {}", email.subject, e)
             monitoringService.notifyEmailProcessingError(email, e, newsletterHandler)
+        }
+
+        return false
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun moveAllProcessedEmails(processedEmails: List<Email>) {
+        processedEmails.forEach { email ->
+            try {
+                emailClient.moveToProcessed(email)
+            } catch (e: Exception) {
+                LOG.warn("Error while moving email {} to processed", email.subject, e)
+            }
         }
     }
 }

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/EmailChecker.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/EmailChecker.kt
@@ -18,6 +18,7 @@
 package fr.nicopico.n2rss.mail
 
 import fr.nicopico.n2rss.mail.client.EmailClient
+import fr.nicopico.n2rss.mail.client.EmailClientSession
 import fr.nicopico.n2rss.mail.models.Email
 import fr.nicopico.n2rss.monitoring.MonitoringService
 import fr.nicopico.n2rss.newsletter.handlers.NewsletterHandler
@@ -48,24 +49,25 @@ class EmailChecker(
     fun savePublicationsFromEmails() {
         try {
             LOG.info("Checking emails...")
-            val emails = emailClient.checkEmails()
-            LOG.info("{} emails found, processing...", emails.size)
+            emailClient.openSession().use { session ->
+                val emails = session.checkEmails()
+                LOG.info("{} emails found, processing...", emails.size)
 
-            val processedEmails = mutableListOf<Email>()
+                val processedEmails = mutableListOf<Email>()
 
-            for (email in emails) {
-                if (processEmail(email)) {
-                    processedEmails.add(email)
+                for (email in emails) {
+                    if (processEmail(session, email)) {
+                        processedEmails.add(email)
+                    }
+                }
+
+                LOG.info("Processing done!")
+
+                if (moveAfterProcessingEnabled && processedEmails.isNotEmpty()) {
+                    LOG.debug("Move processed emails to specified folder")
+                    moveAllProcessedEmails(session, processedEmails)
                 }
             }
-
-            LOG.info("Processing done!")
-
-            if (moveAfterProcessingEnabled && processedEmails.isNotEmpty()) {
-                LOG.debug("Move processed emails to specified folder")
-                moveAllProcessedEmails(processedEmails)
-            }
-
         } catch (e: Exception) {
             LOG.error("Error while checking emails", e)
             monitoringService.notifyGenericError(e, context = "Checking emails")
@@ -73,7 +75,7 @@ class EmailChecker(
     }
 
     @Suppress("TooGenericExceptionCaught", "NestedBlockDepth", "ReturnCount")
-    private fun processEmail(email: Email): Boolean {
+    private fun processEmail(session: EmailClientSession, email: Email): Boolean {
         var newsletterHandler: NewsletterHandler? = null
         try {
             newsletterHandler = newsletterService.findNewsletterHandlerForEmail(email)
@@ -100,7 +102,7 @@ class EmailChecker(
 
             try {
                 LOG.info("\"{}\" processing done, marking email as read", email.subject)
-                emailClient.markAsRead(email)
+                session.markAsRead(email)
                 return true
             } catch (e: Exception) {
                 LOG.error("Error while marking email {} as processed", email.subject, e)
@@ -115,9 +117,9 @@ class EmailChecker(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun moveAllProcessedEmails(processedEmails: List<Email>) {
+    private fun moveAllProcessedEmails(session: EmailClientSession, processedEmails: List<Email>) {
         try {
-            emailClient.moveToProcessed(processedEmails)
+            session.moveToProcessed(processedEmails)
         } catch (e: Exception) {
             LOG.warn("Error while moving processed emails to specified folder", e)
         }

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/EmailChecker.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/EmailChecker.kt
@@ -50,27 +50,31 @@ class EmailChecker(
         try {
             LOG.info("Checking emails...")
             emailClient.openSession().use { session ->
-                val emails = session.checkEmails()
-                LOG.info("{} emails found, processing...", emails.size)
-
-                val processedEmails = mutableListOf<Email>()
-
-                for (email in emails) {
-                    if (processEmail(session, email)) {
-                        processedEmails.add(email)
-                    }
-                }
-
-                LOG.info("Processing done!")
-
-                if (moveAfterProcessingEnabled && processedEmails.isNotEmpty()) {
-                    LOG.debug("Move processed emails to specified folder")
-                    moveAllProcessedEmails(session, processedEmails)
-                }
+                checkEmails(session)
             }
         } catch (e: Exception) {
             LOG.error("Error while checking emails", e)
             monitoringService.notifyGenericError(e, context = "Checking emails")
+        }
+    }
+
+    private fun checkEmails(session: EmailClientSession) {
+        val emails = session.checkEmails()
+        LOG.info("{} emails found, processing...", emails.size)
+
+        val processedEmails = mutableListOf<Email>()
+
+        for (email in emails) {
+            if (processEmail(session, email)) {
+                processedEmails.add(email)
+            }
+        }
+
+        LOG.info("Processing done!")
+
+        if (moveAfterProcessingEnabled && processedEmails.isNotEmpty()) {
+            LOG.debug("Move processed emails to specified folder")
+            moveAllProcessedEmails(session, processedEmails)
         }
     }
 

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/EmailChecker.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/EmailChecker.kt
@@ -60,7 +60,7 @@ class EmailChecker(
 
             LOG.info("Processing done!")
 
-            if (moveAfterProcessingEnabled) {
+            if (moveAfterProcessingEnabled && processedEmails.isNotEmpty()) {
                 LOG.debug("Move processed emails to specified folder")
                 moveAllProcessedEmails(processedEmails)
             }
@@ -106,12 +106,10 @@ class EmailChecker(
 
     @Suppress("TooGenericExceptionCaught")
     private fun moveAllProcessedEmails(processedEmails: List<Email>) {
-        processedEmails.forEach { email ->
-            try {
-                emailClient.moveToProcessed(email)
-            } catch (e: Exception) {
-                LOG.warn("Error while moving email {} to processed", email.subject, e)
-            }
+        try {
+            emailClient.moveToProcessed(processedEmails)
+        } catch (e: Exception) {
+            LOG.warn("Error while moving processed emails to specified folder", e)
         }
     }
 }

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/EmailChecker.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/EmailChecker.kt
@@ -22,6 +22,7 @@ import fr.nicopico.n2rss.mail.models.Email
 import fr.nicopico.n2rss.monitoring.MonitoringService
 import fr.nicopico.n2rss.newsletter.handlers.NewsletterHandler
 import fr.nicopico.n2rss.newsletter.handlers.exception.NoPublicationFoundException
+import fr.nicopico.n2rss.newsletter.handlers.newsletters
 import fr.nicopico.n2rss.newsletter.handlers.process
 import fr.nicopico.n2rss.newsletter.service.NewsletterService
 import fr.nicopico.n2rss.newsletter.service.PublicationService
@@ -78,15 +79,24 @@ class EmailChecker(
             newsletterHandler = newsletterService.findNewsletterHandlerForEmail(email)
                 ?: return false
 
-            LOG.info("\"{}\" is being processed by {}", email.subject, newsletterHandler::class.java)
-            val publications = newsletterHandler.process(email)
+            val publicationAlreadySaved = publicationService.doesPublicationAlreadyExist(
+                title = email.subject,
+                newsletters = newsletterHandler.newsletters,
+            )
 
-            // At least one of the publications must have articles
-            if (publications.all { it.articles.isEmpty() }) {
-                throw NoPublicationFoundException()
+            if (publicationAlreadySaved) {
+                LOG.warn("\"{}\" ignored, publication already exists!", email.subject)
+            } else {
+                LOG.info("\"{}\" is being processed by {}", email.subject, newsletterHandler::class.java)
+                val publications = newsletterHandler.process(email)
+
+                // At least one of the publications must have articles
+                if (publications.all { it.articles.isEmpty() }) {
+                    throw NoPublicationFoundException()
+                }
+
+                publicationService.savePublications(publications)
             }
-
-            publicationService.savePublications(publications)
 
             try {
                 LOG.info("\"{}\" processing done, marking email as read", email.subject)

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/EmailClient.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/EmailClient.kt
@@ -18,8 +18,20 @@
 package fr.nicopico.n2rss.mail.client
 
 import fr.nicopico.n2rss.mail.models.Email
+import java.lang.AutoCloseable
 
 interface EmailClient {
+    @Deprecated("Use EmailClientSession with openSession() instead")
+    fun checkEmails(): List<Email>
+    @Deprecated("Use EmailClientSession with openSession() instead")
+    fun markAsRead(email: Email)
+    @Deprecated("Use EmailClientSession with openSession() instead")
+    fun moveToProcessed(emails: List<Email>)
+
+    fun openSession(): EmailClientSession
+}
+
+interface EmailClientSession : AutoCloseable {
     fun checkEmails(): List<Email>
     fun markAsRead(email: Email)
     fun moveToProcessed(emails: List<Email>)

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/EmailClient.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/EmailClient.kt
@@ -21,13 +21,6 @@ import fr.nicopico.n2rss.mail.models.Email
 import java.lang.AutoCloseable
 
 interface EmailClient {
-    @Deprecated("Use EmailClientSession with openSession() instead")
-    fun checkEmails(): List<Email>
-    @Deprecated("Use EmailClientSession with openSession() instead")
-    fun markAsRead(email: Email)
-    @Deprecated("Use EmailClientSession with openSession() instead")
-    fun moveToProcessed(emails: List<Email>)
-
     fun openSession(): EmailClientSession
 }
 

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/EmailClient.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/EmailClient.kt
@@ -22,5 +22,5 @@ import fr.nicopico.n2rss.mail.models.Email
 interface EmailClient {
     fun checkEmails(): List<Email>
     fun markAsRead(email: Email)
-    fun moveToProcessed(email: Email)
+    fun moveToProcessed(emails: List<Email>)
 }

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClient.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClient.kt
@@ -20,10 +20,15 @@ package fr.nicopico.n2rss.mail.client
 import fr.nicopico.n2rss.mail.models.Email
 import jakarta.mail.Flags
 import jakarta.mail.Folder
+import jakarta.mail.FolderNotFoundException
+import jakarta.mail.Message
 import jakarta.mail.Session
 import jakarta.mail.Store
 import jakarta.mail.search.FlagTerm
+import org.slf4j.LoggerFactory
 import java.util.Properties
+
+private val LOG = LoggerFactory.getLogger(JavaxEmailClient::class.java)
 
 class JavaxEmailClient(
     private val config: EmailServerConfiguration,
@@ -35,6 +40,19 @@ class JavaxEmailClient(
         setProperty("mail.store.protocol", config.protocol)
     }
 
+    override fun openSession(): EmailClientSession {
+        val session = Session.getInstance(storeProps, null)
+        val store = session.getStore(config.protocol).also {
+            it.connectWith(config)
+        }
+        return JavaxEmailClientSession(
+            store = store,
+            folderNames = folders,
+            processedFolderName = processedFolder,
+        )
+    }
+
+    @Deprecated("Use EmailClientSession with openSession() instead")
     override fun checkEmails(): List<Email> {
         return folders
             .flatMap { folderName ->
@@ -49,6 +67,7 @@ class JavaxEmailClient(
             }
     }
 
+    @Deprecated("Use EmailClientSession with openSession() instead")
     override fun markAsRead(email: Email) {
         val message = email.message
         doInStore {
@@ -63,6 +82,7 @@ class JavaxEmailClient(
         }
     }
 
+    @Deprecated("Use EmailClientSession with openSession() instead")
     override fun moveToProcessed(emails: List<Email>) {
         if (emails.isEmpty()) return
         val srcFolder = emails.first().message.folder
@@ -117,7 +137,7 @@ class JavaxEmailClient(
                 // This folder can hold folders and messages
                 create(Folder.HOLDS_FOLDERS or Folder.HOLDS_MESSAGES)
             } else {
-                throw jakarta.mail.FolderNotFoundException(this, "Folder $name does not exist")
+                throw FolderNotFoundException(this, "Folder $name does not exist")
             }
         }
 
@@ -134,5 +154,115 @@ class JavaxEmailClient(
         private fun Store.connectWith(config: EmailServerConfiguration) {
             connect(config.host, config.port, config.user, config.password)
         }
+    }
+}
+
+private class JavaxEmailClientSession(
+    private val store: Store,
+    folderNames: List<String>,
+    processedFolderName: String,
+) : EmailClientSession {
+
+    private val folders: List<Folder> = folderNames
+        .map { folderName ->
+            store.getFolder(folderName)
+        }
+        .filter { folder ->
+            if (!folder.exists()) {
+                LOG.warn("Folder {} does not exist, skipping", folder.name)
+                false
+            } else true
+        }
+
+    private val processedFolder: Folder? = store.getFolder(processedFolderName)
+        .let { folder ->
+            try {
+                if (!folder.exists()) {
+                    // Ensure the folder exists
+                    LOG.info("Folder {} does not exist, creating it", processedFolderName)
+                    val created = folder.create(Folder.HOLDS_FOLDERS or Folder.HOLDS_MESSAGES)
+                    if (!created) {
+                        LOG.error("Failed to create folder {}", processedFolderName)
+                        null
+                    } else folder
+                } else folder
+            } catch (e: Exception) {
+                LOG.error("Error while checking/creating processed folder {}", processedFolderName, e)
+                null
+            }
+        }
+
+    init {
+        try {
+            folders.forEach { folder ->
+                folder.open(Folder.READ_WRITE)
+            }
+            processedFolder?.open(Folder.READ_WRITE)
+        } catch (e: Exception) {
+            close()
+            throw e
+        }
+    }
+
+    override fun checkEmails(): List<Email> {
+        return folders.flatMap { folder ->
+            folder
+                .search(FlagTerm(Flags(Flags.Flag.SEEN), false))
+                .map { it.toEmail() }
+        }
+    }
+
+    override fun markAsRead(email: Email) {
+        val freshMessage = email.getFreshMessage()
+        freshMessage.setFlag(Flags.Flag.SEEN, true)
+    }
+
+    override fun moveToProcessed(emails: List<Email>) {
+        val destination = processedFolder
+        if (destination == null) {
+            LOG.warn("Processed folder is not available, cannot move emails")
+            return
+        }
+        val messagesByFolder = emails
+            .map { it.getFreshMessage() }
+            .groupBy { it.folder }
+
+        messagesByFolder.forEach { (folder, messages) ->
+            // Copy all messages to the destination, then delete the source messages
+            folder.copyMessages(messages.toTypedArray<Message>(), destination)
+            messages.forEach { message ->
+                message.setFlag(Flags.Flag.DELETED, true)
+            }
+            folder.expunge()
+        }
+    }
+
+    private fun Email.getFreshMessage(): Message {
+        val folder = message.folder
+        return if (message.isExpunged || !folder.isOpen || message.messageNumber <= 0) {
+            LOG.info(
+                "Message is stale (expunged: {}, open: {}, number: {}), re-fetching",
+                message.isExpunged, folder.isOpen, message.messageNumber
+            )
+            folder.getMessage(message.messageNumber)
+        } else {
+            message
+        }
+    }
+
+    override fun close() {
+        folders.forEach {
+            try {
+                it.close(/* expunge = */ false)
+            } catch (_: IllegalStateException) {
+                // Do nothing
+            }
+        }
+        try {
+            processedFolder?.close(/* expunge = */ false)
+        } catch (_: IllegalStateException) {
+            // Do nothing
+        }
+        store.close()
     }
 }

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClient.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClient.kt
@@ -20,8 +20,8 @@ package fr.nicopico.n2rss.mail.client
 import fr.nicopico.n2rss.mail.models.Email
 import jakarta.mail.Flags
 import jakarta.mail.Folder
-import jakarta.mail.FolderNotFoundException
 import jakarta.mail.Message
+import jakarta.mail.MessagingException
 import jakarta.mail.Session
 import jakarta.mail.Store
 import jakarta.mail.search.FlagTerm
@@ -50,104 +50,6 @@ class JavaxEmailClient(
             folderNames = folders,
             processedFolderName = processedFolder,
         )
-    }
-
-    @Deprecated("Use EmailClientSession with openSession() instead")
-    override fun checkEmails(): List<Email> {
-        return folders
-            .flatMap { folderName ->
-                doInStore {
-                    getFolder(folderName)
-                        .use(Folder.READ_ONLY) { folder ->
-                            folder
-                                .search(FlagTerm(Flags(Flags.Flag.SEEN), false))
-                                .map { it.toEmail() }
-                        }
-                }
-            }
-    }
-
-    @Deprecated("Use EmailClientSession with openSession() instead")
-    override fun markAsRead(email: Email) {
-        val message = email.message
-        doInStore {
-            message.folder.use(Folder.READ_WRITE) { folder ->
-                val freshMessage = if (message.isExpunged || !folder.isOpen || message.messageNumber <= 0) {
-                    folder.getMessage(message.messageNumber)
-                } else {
-                    message
-                }
-                freshMessage.setFlag(Flags.Flag.SEEN, true)
-            }
-        }
-    }
-
-    @Deprecated("Use EmailClientSession with openSession() instead")
-    override fun moveToProcessed(emails: List<Email>) {
-        if (emails.isEmpty()) return
-        val srcFolder = emails.first().message.folder
-
-        doInStore {
-            getFolder(processedFolder).use(
-                Folder.READ_ONLY,
-                // Ensure the destination folder is present
-                createAutomatically = true
-            ) { destination ->
-                srcFolder.use(Folder.READ_WRITE, expungeOnClose = true) { folder ->
-                    val freshMessages = emails
-                        .map { it.message }
-                        .map { message ->
-                            // Ensure freshness
-                            if (message.isExpunged || !folder.isOpen || message.messageNumber <= 0) {
-                                folder.getMessage(message.messageNumber)
-                            } else {
-                                message
-                            }
-                        }
-                        .toTypedArray()
-
-                    // Copy from `folder` to `destination`
-                    folder.copyMessages(freshMessages, destination)
-
-                    // Delete the originals
-                    freshMessages.forEach { message ->
-                        message.setFlag(Flags.Flag.DELETED, true)
-                    }
-                }
-            }
-        }
-    }
-
-    private fun <T> doInStore(block: Store.() -> T): T {
-        val session = Session.getInstance(storeProps, null)
-        return session.getStore(config.protocol).use { store ->
-            store.connectWith(config)
-            store.block()
-        }
-    }
-
-    private fun <T> Folder.use(
-        mode: Int,
-        expungeOnClose: Boolean = false,
-        createAutomatically: Boolean = false,
-        block: (Folder) -> T,
-    ): T {
-        if (!exists()) {
-            if (createAutomatically) {
-                // This folder can hold folders and messages
-                create(Folder.HOLDS_FOLDERS or Folder.HOLDS_MESSAGES)
-            } else {
-                throw FolderNotFoundException(this, "Folder $name does not exist")
-            }
-        }
-
-        if (isOpen) error("Folder $this is already open")
-        open(mode)
-        try {
-            return block(this)
-        } finally {
-            close(expungeOnClose)
-        }
     }
 
     companion object {
@@ -182,17 +84,18 @@ private class JavaxEmailClientSession(
                     LOG.info("Folder {} does not exist, creating it", processedFolderName)
                     val created = folder.create(Folder.HOLDS_FOLDERS or Folder.HOLDS_MESSAGES)
                     if (!created) {
-                        LOG.error("Failed to create folder {}", processedFolderName)
+                        LOG.warn("Failed to create processed folder {}", processedFolderName)
                         null
                     } else folder
                 } else folder
-            } catch (e: Exception) {
-                LOG.error("Error while checking/creating processed folder {}", processedFolderName, e)
+            } catch (e: MessagingException) {
+                LOG.warn("Error while checking/creating processed folder {}", processedFolderName, e)
                 null
             }
         }
 
     init {
+        @Suppress("TooGenericExceptionCaught")
         try {
             folders.forEach { folder ->
                 folder.open(Folder.READ_WRITE)

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClient.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClient.kt
@@ -24,6 +24,7 @@ import jakarta.mail.Message
 import jakarta.mail.MessagingException
 import jakarta.mail.Session
 import jakarta.mail.Store
+import jakarta.mail.UIDFolder
 import jakarta.mail.search.FlagTerm
 import org.slf4j.LoggerFactory
 import java.util.Properties
@@ -141,15 +142,44 @@ private class JavaxEmailClientSession(
     }
 
     private fun Email.getFreshMessage(): Message {
-        val folder = message.folder
-        return if (message.isExpunged || !folder.isOpen || message.messageNumber <= 0) {
-            LOG.info(
-                "Message is stale (expunged: {}, open: {}, number: {}), re-fetching",
-                message.isExpunged, folder.isOpen, message.messageNumber
-            )
-            folder.getMessage(message.messageNumber)
+        val currentMessage = message
+        val currentFolder = currentMessage.folder
+
+        val isPotentiallyValid = currentFolder.isOpen
+            && !currentMessage.isExpunged
+            && currentMessage.messageNumber > 0
+
+        val refetch: () -> Message = {
+            val sessionFolder = getSessionFolderByName(currentFolder.fullName)
+            sessionFolder.fetchMessage(msgUid, currentMessage.messageNumber)
+        }
+
+        return when {
+            !isPotentiallyValid -> refetch()
+            msgUid == null || currentFolder !is UIDFolder -> currentMessage // Cannot check, optimistic approach
+            currentFolder.getUID(currentMessage) == msgUid -> currentMessage // Still valid
+            else -> refetch()
+        }
+    }
+
+    private fun getSessionFolderByName(folderFullName: String): Folder {
+        return folders.find { it.fullName == folderFullName }
+            ?: processedFolder?.takeIf { it.fullName == folderFullName }
+            ?: error("Folder $folderFullName not found in current session")
+    }
+
+    private fun Folder.fetchMessage(msgUid: Long?, msgNum: Int): Message {
+        return if (msgUid != null && this is UIDFolder) {
+            LOG.info("Re-fetching message with UID {} from folder {}", msgUid, this.fullName)
+            this.getMessageByUID(msgUid)
+                ?: error("Message with UID $msgUid no longer exists in ${this.fullName}")
         } else {
-            message
+            LOG.warn(
+                "Re-fetching message by number {} (unreliable) from folder {}",
+                msgNum,
+                this.fullName,
+            )
+            this.getMessage(msgNum)
         }
     }
 

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClient.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClient.kt
@@ -183,19 +183,32 @@ private class JavaxEmailClientSession(
         }
     }
 
+    @Suppress("LoggingSimilarMessage")
     override fun close() {
         folders.forEach {
             try {
                 it.close(/* expunge = */ false)
             } catch (_: IllegalStateException) {
                 // Do nothing
+            } catch (e: MessagingException) {
+                LOG.warn("Failed to close folder {}", it.fullName, e)
             }
         }
-        try {
-            processedFolder?.close(/* expunge = */ false)
-        } catch (_: IllegalStateException) {
-            // Do nothing
+
+        if (processedFolder != null) {
+            try {
+                processedFolder.close(/* expunge = */ false)
+            } catch (_: IllegalStateException) {
+                // Do nothing
+            } catch (e: MessagingException) {
+                LOG.warn("Failed to close folder {}", processedFolder.fullName, e)
+            }
         }
-        store.close()
+
+        try {
+            store.close()
+        } catch (e: MessagingException) {
+            LOG.warn("Failed to close store", e)
+        }
     }
 }

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClient.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClient.kt
@@ -63,8 +63,9 @@ class JavaxEmailClient(
         }
     }
 
-    override fun moveToProcessed(email: Email) {
-        val message = email.message
+    override fun moveToProcessed(emails: List<Email>) {
+        if (emails.isEmpty()) return
+        val srcFolder = emails.first().message.folder
 
         doInStore {
             getFolder(processedFolder).use(
@@ -72,18 +73,26 @@ class JavaxEmailClient(
                 // Ensure the destination folder is present
                 createAutomatically = true
             ) { destination ->
-                message.folder.use(Folder.READ_WRITE, expungeOnClose = true) { folder ->
-                    val freshMessage = if (message.isExpunged || !folder.isOpen || message.messageNumber <= 0) {
-                        folder.getMessage(message.messageNumber)
-                    } else {
-                        message
-                    }
+                srcFolder.use(Folder.READ_WRITE, expungeOnClose = true) { folder ->
+                    val freshMessages = emails
+                        .map { it.message }
+                        .map { message ->
+                            // Ensure freshness
+                            if (message.isExpunged || !folder.isOpen || message.messageNumber <= 0) {
+                                folder.getMessage(message.messageNumber)
+                            } else {
+                                message
+                            }
+                        }
+                        .toTypedArray()
 
                     // Copy from `folder` to `destination`
-                    folder.copyMessages(arrayOf(freshMessage), destination)
+                    folder.copyMessages(freshMessages, destination)
 
-                    // Delete the original
-                    freshMessage.setFlag(Flags.Flag.DELETED, true)
+                    // Delete the originals
+                    freshMessages.forEach { message ->
+                        message.setFlag(Flags.Flag.DELETED, true)
+                    }
                 }
             }
         }

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/LocalFileEmailClient.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/LocalFileEmailClient.kt
@@ -33,6 +33,30 @@ class LocalFileEmailClient(
     private val mailSession = Session.getDefaultInstance(System.getProperties())
     private val readEmails = mutableSetOf<Email>()
 
+    override fun openSession(): EmailClientSession {
+        return LocalFileEmailClientSession(
+            emailFolder = emailFolder,
+            mailSession = mailSession,
+            readEmails = readEmails,
+        )
+    }
+
+    @Deprecated("Use EmailClientSession with openSession() instead")
+    override fun checkEmails(): List<Email> = openSession().use { it.checkEmails() }
+
+    @Deprecated("Use EmailClientSession with openSession() instead")
+    override fun markAsRead(email: Email) = openSession().use { it.markAsRead(email) }
+
+    @Deprecated("Use EmailClientSession with openSession() instead")
+    override fun moveToProcessed(emails: List<Email>) = openSession().use { it.moveToProcessed(emails) }
+}
+
+private class LocalFileEmailClientSession(
+    private val emailFolder: String,
+    private val mailSession: Session,
+    private val readEmails: MutableSet<Email>,
+) : EmailClientSession {
+
     override fun checkEmails(): List<Email> {
         val filePath = Paths.get(emailFolder)
         require(filePath.toFile().exists()) {
@@ -56,6 +80,10 @@ class LocalFileEmailClient(
 
     override fun moveToProcessed(emails: List<Email>) {
         // No-op for local files
+    }
+
+    override fun close() {
+        // No-op
     }
 
     private fun parseEmlFileToMimeMessage(filePath: String): MimeMessage {

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/LocalFileEmailClient.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/LocalFileEmailClient.kt
@@ -54,7 +54,7 @@ class LocalFileEmailClient(
         readEmails.add(email)
     }
 
-    override fun moveToProcessed(email: Email) {
+    override fun moveToProcessed(emails: List<Email>) {
         // No-op for local files
     }
 

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/LocalFileEmailClient.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/LocalFileEmailClient.kt
@@ -42,13 +42,8 @@ class LocalFileEmailClient(
     }
 
     @Deprecated("Use EmailClientSession with openSession() instead")
-    override fun checkEmails(): List<Email> = openSession().use { it.checkEmails() }
+    fun checkEmails(): List<Email> = openSession().use { it.checkEmails() }
 
-    @Deprecated("Use EmailClientSession with openSession() instead")
-    override fun markAsRead(email: Email) = openSession().use { it.markAsRead(email) }
-
-    @Deprecated("Use EmailClientSession with openSession() instead")
-    override fun moveToProcessed(emails: List<Email>) = openSession().use { it.moveToProcessed(emails) }
 }
 
 private class LocalFileEmailClientSession(

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/MessageExt.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/MessageExt.kt
@@ -23,11 +23,14 @@ import fr.nicopico.n2rss.mail.models.Sender
 import fr.nicopico.n2rss.utils.toKotlinLocaleDate
 import jakarta.mail.Flags
 import jakarta.mail.Message
+import jakarta.mail.UIDFolder
 import jakarta.mail.internet.MimeMultipart
 
 fun Message.toEmail(): Email {
     val originalFlags = flags
     val content = content
+    val msgUid = (folder as? UIDFolder)?.getUID(this)
+
     val email = Email(
         sender = Sender(from[0].toString()),
         date = this.sentDate.toKotlinLocaleDate(),
@@ -59,6 +62,7 @@ fun Message.toEmail(): Email {
         replyTo = if (replyTo.isNotEmpty()) {
             Sender(replyTo[0].toString())
         } else null,
+        msgUid = msgUid,
     ).also {
         it.setMessage(this)
     }

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/NoOpEmailClient.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/NoOpEmailClient.kt
@@ -20,26 +20,12 @@ package fr.nicopico.n2rss.mail.client
 import fr.nicopico.n2rss.mail.models.Email
 
 class NoOpEmailClient : EmailClient {
-
     override fun openSession(): EmailClientSession = NoOpEmailClientSession
-
-    @Deprecated("Use EmailClientSession with openSession() instead")
-    override fun checkEmails(): List<Email> = emptyList()
-
-    @Deprecated("Use EmailClientSession with openSession() instead")
-    override fun markAsRead(email: Email) {
-        // No-op
-    }
-
-    @Deprecated("Use EmailClientSession with openSession() instead")
-    override fun moveToProcessed(emails: List<Email>) {
-        // No-op
-    }
 }
 
 private object NoOpEmailClientSession : EmailClientSession {
     override fun checkEmails(): List<Email> = emptyList()
-    override fun markAsRead(email: Email) {}
-    override fun moveToProcessed(emails: List<Email>) {}
-    override fun close() {}
+    override fun markAsRead(email: Email) = Unit
+    override fun moveToProcessed(emails: List<Email>) = Unit
+    override fun close() = Unit
 }

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/NoOpEmailClient.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/NoOpEmailClient.kt
@@ -27,7 +27,7 @@ class NoOpEmailClient : EmailClient {
         // No-op
     }
 
-    override fun moveToProcessed(email: Email) {
+    override fun moveToProcessed(emails: List<Email>) {
         // No-op
     }
 }

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/NoOpEmailClient.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/client/NoOpEmailClient.kt
@@ -21,13 +21,25 @@ import fr.nicopico.n2rss.mail.models.Email
 
 class NoOpEmailClient : EmailClient {
 
+    override fun openSession(): EmailClientSession = NoOpEmailClientSession
+
+    @Deprecated("Use EmailClientSession with openSession() instead")
     override fun checkEmails(): List<Email> = emptyList()
 
+    @Deprecated("Use EmailClientSession with openSession() instead")
     override fun markAsRead(email: Email) {
         // No-op
     }
 
+    @Deprecated("Use EmailClientSession with openSession() instead")
     override fun moveToProcessed(emails: List<Email>) {
         // No-op
     }
+}
+
+private object NoOpEmailClientSession : EmailClientSession {
+    override fun checkEmails(): List<Email> = emptyList()
+    override fun markAsRead(email: Email) {}
+    override fun moveToProcessed(emails: List<Email>) {}
+    override fun close() {}
 }

--- a/server/src/main/kotlin/fr/nicopico/n2rss/mail/models/Email.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/mail/models/Email.kt
@@ -26,6 +26,7 @@ data class Email(
     val subject: String,
     val content: EmailContent,
     val replyTo: Sender? = null,
+    val msgUid: Long? = null,
 ) {
     // `message` is used as an identifier to operate on the email with Jakarta Mail API.
     // `underlyingMessage` is kept outside the primary constructor

--- a/server/src/main/kotlin/fr/nicopico/n2rss/newsletter/data/PublicationRepository.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/newsletter/data/PublicationRepository.kt
@@ -21,9 +21,8 @@ import fr.nicopico.n2rss.newsletter.data.entity.PublicationEntity
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
-import java.util.UUID
 
-interface PublicationRepository : JpaRepository<PublicationEntity, UUID> {
+interface PublicationRepository : JpaRepository<PublicationEntity, Long> {
     fun findByNewsletterCode(newsletterCode: String, pageable: Pageable): Page<PublicationEntity>
     fun countPublicationsByNewsletterCode(newsletterCode: String): Long
     fun findFirstByNewsletterCodeOrderByDateAsc(newsletterCode: String): PublicationEntity?

--- a/server/src/main/kotlin/fr/nicopico/n2rss/newsletter/data/PublicationRepository.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/newsletter/data/PublicationRepository.kt
@@ -28,4 +28,5 @@ interface PublicationRepository : JpaRepository<PublicationEntity, UUID> {
     fun countPublicationsByNewsletterCode(newsletterCode: String): Long
     fun findFirstByNewsletterCodeOrderByDateAsc(newsletterCode: String): PublicationEntity?
     fun findFirstByNewsletterCodeOrderByDateDesc(newsletterCode: String): PublicationEntity?
+    fun findFirstByNewsletterCodeAndTitle(newsletterCode: String, title: String): PublicationEntity?
 }

--- a/server/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/PublicationService.kt
+++ b/server/src/main/kotlin/fr/nicopico/n2rss/newsletter/service/PublicationService.kt
@@ -64,6 +64,20 @@ class PublicationService(
                 )
             }
     }
+
+    @Transactional
+    fun doesPublicationAlreadyExist(title: String, newsletters: List<Newsletter>): Boolean {
+        newsletters.forEach { newsletter ->
+            val found = publicationRepository.findFirstByNewsletterCodeAndTitle(
+                newsletterCode = newsletter.code,
+                title = title,
+            )
+            if (found != null) {
+                return true
+            }
+        }
+        return false
+    }
     //endregion
 
     //region savePublications

--- a/server/src/test/kotlin/fr/nicopico/n2rss/mail/EmailCheckerIntegrationTest.kt
+++ b/server/src/test/kotlin/fr/nicopico/n2rss/mail/EmailCheckerIntegrationTest.kt
@@ -22,8 +22,10 @@ import fr.nicopico.n2rss.mail.client.EmailServerConfiguration
 import fr.nicopico.n2rss.mail.client.GreenMailTestBase
 import fr.nicopico.n2rss.mail.client.JavaxEmailClient
 import fr.nicopico.n2rss.monitoring.MonitoringService
+import fr.nicopico.n2rss.newsletter.handlers.newsletters
 import fr.nicopico.n2rss.newsletter.handlers.process
 import fr.nicopico.n2rss.newsletter.models.Article
+import fr.nicopico.n2rss.newsletter.models.Newsletter
 import fr.nicopico.n2rss.newsletter.models.Publication
 import fr.nicopico.n2rss.newsletter.service.NewsletterService
 import fr.nicopico.n2rss.newsletter.service.PublicationService
@@ -37,7 +39,6 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class EmailCheckerIntegrationTest : GreenMailTestBase(
@@ -121,10 +122,14 @@ class EmailCheckerIntegrationTest : GreenMailTestBase(
                     every { articles } returns listOf(mockk<Article>())
                 }
             )
+            every { newsletters } returns listOf(mockk<Newsletter>())
         }
         every {
             publicationService.savePublications(any())
         } just Runs
+        every {
+            publicationService.doesPublicationAlreadyExist(any(), any())
+        } returns false
 
         // WHEN
         emailChecker.savePublicationsFromEmails()
@@ -137,8 +142,6 @@ class EmailCheckerIntegrationTest : GreenMailTestBase(
     }
 
     @Test
-    // TODO Restore this test and fix moveAfterProcessing
-    @Disabled("MoveAfterProcessing does not work yet")
     fun `should check emails for publications - with moveAfterProcessing`() {
         // GIVEN
         deliverTextMessage(
@@ -163,10 +166,14 @@ class EmailCheckerIntegrationTest : GreenMailTestBase(
                     every { articles } returns listOf(mockk<Article>())
                 }
             )
+            every { newsletters } returns listOf(mockk<Newsletter>())
         }
         every {
             publicationService.savePublications(any())
         } just Runs
+        every {
+            publicationService.doesPublicationAlreadyExist(any(), any())
+        } returns false
 
         // WHEN
         emailCheckerWithMoveAfterProcessing.savePublicationsFromEmails()

--- a/server/src/test/kotlin/fr/nicopico/n2rss/mail/EmailCheckerIntegrationTest.kt
+++ b/server/src/test/kotlin/fr/nicopico/n2rss/mail/EmailCheckerIntegrationTest.kt
@@ -137,8 +137,9 @@ class EmailCheckerIntegrationTest : GreenMailTestBase(
         // THEN
         confirmVerified(monitoringService)
 
-        val unreadEmails = emailClient.checkEmails()
-        unreadEmails should beEmpty()
+        emailClient.openSession().use {
+            it.checkEmails() should beEmpty()
+        }
     }
 
     @Test
@@ -181,7 +182,8 @@ class EmailCheckerIntegrationTest : GreenMailTestBase(
         // THEN
         confirmVerified(monitoringService)
 
-        val unreadEmails = emailClient.checkEmails()
-        unreadEmails should beEmpty()
+        emailClient.openSession().use {
+            it.checkEmails() should beEmpty()
+        }
     }
 }

--- a/server/src/test/kotlin/fr/nicopico/n2rss/mail/EmailCheckerTest.kt
+++ b/server/src/test/kotlin/fr/nicopico/n2rss/mail/EmailCheckerTest.kt
@@ -86,7 +86,7 @@ class EmailCheckerTest {
         verify { newsletterHandler.process(email) }
         verify { publicationService.savePublications(eq(listOf(publication))) }
         verify { emailClient.markAsRead(email) }
-        verify { emailClient.moveToProcessed(email) }
+        verify { emailClient.moveToProcessed(listOf(email)) }
     }
 
     @Test
@@ -135,7 +135,7 @@ class EmailCheckerTest {
 
         verify { emailClient.markAsRead(validEmail) }
         verify(exactly = 0) { emailClient.markAsRead(errorEmail) }
-        verify(exactly = 0) { emailClient.moveToProcessed(errorEmail) }
+        verify(exactly = 0) { emailClient.moveToProcessed(match { it.contains(errorEmail) }) }
 
         verify {
             monitoringService.notifyEmailProcessingError(
@@ -187,7 +187,7 @@ class EmailCheckerTest {
         verify(exactly = 0) {
             publicationService.savePublications(eq(listOf(publication)))
             emailClient.markAsRead(email)
-            emailClient.moveToProcessed(email)
+            emailClient.moveToProcessed(any())
         }
         verify {
             monitoringService.notifyEmailProcessingError(
@@ -225,11 +225,11 @@ class EmailCheckerTest {
         // THEN
         verify(exactly = 0) {
             emailClient.markAsRead(email1)
-            emailClient.moveToProcessed(email1)
+            emailClient.moveToProcessed(match { it.contains(email1) })
         }
         verify {
             emailClient.markAsRead(email2)
-            emailClient.moveToProcessed(email2)
+            emailClient.moveToProcessed(listOf(email2))
         }
         verify {
             monitoringService.notifyEmailProcessingError(
@@ -264,7 +264,7 @@ class EmailCheckerTest {
         verify { newsletterHandler.process(email) }
         verify { publicationService.savePublications(eq(listOf(publication))) }
         verify { emailClient.markAsRead(email) }
-        verify(exactly = 0) { emailClient.moveToProcessed(email) }
+        verify(exactly = 0) { emailClient.moveToProcessed(any()) }
 
         verify { monitoringService.notifyGenericError(markAsReadError, any()) }
         confirmVerified(monitoringService)
@@ -293,7 +293,7 @@ class EmailCheckerTest {
         verify { newsletterHandler.process(email) }
         verify { publicationService.savePublications(eq(listOf(publication))) }
         verify { emailClient.markAsRead(email) }
-        verify { emailClient.moveToProcessed(email) }
+        verify { emailClient.moveToProcessed(listOf(email)) }
 
         verify(exactly = 0) { monitoringService.notifyGenericError(moveToProcessedError, any()) }
         confirmVerified(monitoringService)

--- a/server/src/test/kotlin/fr/nicopico/n2rss/mail/EmailCheckerTest.kt
+++ b/server/src/test/kotlin/fr/nicopico/n2rss/mail/EmailCheckerTest.kt
@@ -19,6 +19,7 @@
 package fr.nicopico.n2rss.mail
 
 import fr.nicopico.n2rss.mail.client.EmailClient
+import fr.nicopico.n2rss.mail.client.EmailClientSession
 import fr.nicopico.n2rss.mail.models.Email
 import fr.nicopico.n2rss.monitoring.MonitoringService
 import fr.nicopico.n2rss.newsletter.handlers.NewsletterHandler
@@ -38,6 +39,7 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.verifyOrder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -45,8 +47,11 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(MockKExtension::class)
 class EmailCheckerTest {
 
-    @MockK(relaxUnitFun = true)
+    @MockK
     private lateinit var emailClient: EmailClient
+    @MockK(relaxUnitFun = true)
+    private lateinit var emailClientSession: EmailClientSession
+
     @MockK
     private lateinit var newsletterService: NewsletterService
     @MockK(relaxed = true)
@@ -59,6 +64,8 @@ class EmailCheckerTest {
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
+
+        every { emailClient.openSession() } returns emailClientSession
 
         emailChecker = EmailChecker(
             emailClient = emailClient,
@@ -76,7 +83,7 @@ class EmailCheckerTest {
         @MockK publication: Publication,
     ) {
         // Given an email that should be handled by a newsletterHandler
-        every { emailClient.checkEmails() } returns listOf(email)
+        every { emailClientSession.checkEmails() } returns listOf(email)
         every { newsletterService.findNewsletterHandlerForEmail(email) } returns newsletterHandler
         every { newsletterHandler.process(email) } returns listOf(publication)
         every { publication.articles } returns listOf(mockk())
@@ -87,8 +94,8 @@ class EmailCheckerTest {
         // Then the email should be handled by newsletterHandlerA and not by newsletterHandlerB
         verify { newsletterHandler.process(email) }
         verify { publicationService.savePublications(eq(listOf(publication))) }
-        verify { emailClient.markAsRead(email) }
-        verify { emailClient.moveToProcessed(listOf(email)) }
+        verify { emailClientSession.markAsRead(email) }
+        verify { emailClientSession.moveToProcessed(listOf(email)) }
     }
 
     @Test
@@ -96,7 +103,7 @@ class EmailCheckerTest {
         @MockK(relaxed = true) email: Email
     ) {
         // Given an email that should not be handled by any handler
-        every { emailClient.checkEmails() } returns listOf(email)
+        every { emailClientSession.checkEmails() } returns listOf(email)
         every { newsletterService.findNewsletterHandlerForEmail(email) } returns null
 
         // When we check the email
@@ -104,8 +111,8 @@ class EmailCheckerTest {
 
         // Then no handler should try to handle the email and no publication should be saved
         verify(exactly = 0) { publicationService.savePublications(any()) }
-        verify(exactly = 0) { emailClient.markAsRead(any()) }
-        verify(exactly = 0) { emailClient.moveToProcessed(any()) }
+        verify(exactly = 0) { emailClientSession.markAsRead(any()) }
+        verify(exactly = 0) { emailClientSession.moveToProcessed(any()) }
     }
 
     @Test
@@ -116,7 +123,7 @@ class EmailCheckerTest {
     ) {
         // Given an email that already exists in the database
         every { email.subject } returns "Email subject"
-        every { emailClient.checkEmails() } returns listOf(email)
+        every { emailClientSession.checkEmails() } returns listOf(email)
         every { newsletterService.findNewsletterHandlerForEmail(email) } returns newsletterHandler
         every { newsletterHandler.newsletters } returns listOf(newsletter)
         every {
@@ -132,8 +139,8 @@ class EmailCheckerTest {
         // Then the email should not be processed again, but the email should be marked
         verify(exactly = 0) { newsletterHandler.process(email) }
         verify(exactly = 0) { publicationService.savePublications(any()) }
-        verify { emailClient.markAsRead(email) }
-        verify { emailClient.moveToProcessed(listOf(email)) }
+        verify { emailClientSession.markAsRead(email) }
+        verify { emailClientSession.moveToProcessed(listOf(email)) }
     }
 
     @Test
@@ -144,8 +151,8 @@ class EmailCheckerTest {
         @MockK publication: Publication,
     ) {
         // Given an email that causes an error and a valid email
-        every { emailClient.checkEmails() } returns listOf(errorEmail, validEmail)
-        every { emailClient.markAsRead(any()) } just Runs
+        every { emailClientSession.checkEmails() } returns listOf(errorEmail, validEmail)
+        every { emailClientSession.markAsRead(any()) } just Runs
 
         every { newsletterService.findNewsletterHandlerForEmail(any()) } returns newsletterHandler
 
@@ -163,9 +170,9 @@ class EmailCheckerTest {
         verify { newsletterHandler.process(validEmail) }
         verify { publicationService.savePublications(eq(listOf(publication))) }
 
-        verify { emailClient.markAsRead(validEmail) }
-        verify(exactly = 0) { emailClient.markAsRead(errorEmail) }
-        verify(exactly = 0) { emailClient.moveToProcessed(match { it.contains(errorEmail) }) }
+        verify { emailClientSession.markAsRead(validEmail) }
+        verify(exactly = 0) { emailClientSession.markAsRead(errorEmail) }
+        verify(exactly = 0) { emailClientSession.moveToProcessed(match { it.contains(errorEmail) }) }
 
         verify {
             monitoringService.notifyEmailProcessingError(
@@ -180,18 +187,24 @@ class EmailCheckerTest {
     fun `emailChecker will not crash if the client fails`() {
         // Given that emailClient fails when checking emails
         val emailError = RuntimeException("TEST")
-        every { emailClient.checkEmails() } throws emailError
+        every { emailClientSession.checkEmails() } throws emailError
         every { monitoringService.notifyGenericError(any(), any()) } just Runs
 
         // When we check the emails
         emailChecker.savePublicationsFromEmails()
 
         // Then emailChecker should proceed without doing anything
-        verify { emailClient.checkEmails() }
+        verifyOrder {
+            emailClient.openSession()
+            emailClientSession.checkEmails()
+            emailClientSession.close()
+        }
+
         verify { monitoringService.notifyGenericError(emailError, "Checking emails") }
 
         confirmVerified(
             emailClient,
+            emailClientSession,
             publicationService,
             monitoringService,
         )
@@ -204,7 +217,7 @@ class EmailCheckerTest {
         @MockK publication: Publication,
     ) {
         // Given an email without any articles
-        every { emailClient.checkEmails() } returns listOf(email)
+        every { emailClientSession.checkEmails() } returns listOf(email)
         every { newsletterService.findNewsletterHandlerForEmail(email) } returns newsletterHandler
         every { newsletterHandler.process(email) } returns listOf(publication)
         every { publication.articles } returns emptyList()
@@ -216,8 +229,8 @@ class EmailCheckerTest {
         // Then the email should be marked as read without creating a publication
         verify(exactly = 0) {
             publicationService.savePublications(eq(listOf(publication)))
-            emailClient.markAsRead(email)
-            emailClient.moveToProcessed(any())
+            emailClientSession.markAsRead(email)
+            emailClientSession.moveToProcessed(any())
         }
         verify {
             monitoringService.notifyEmailProcessingError(
@@ -237,7 +250,7 @@ class EmailCheckerTest {
         @MockK(relaxed = true) publication2: Publication,
     ) {
         // Given an email that should be handled by a newsletterHandler
-        every { emailClient.checkEmails() } returns listOf(email1, email2)
+        every { emailClientSession.checkEmails() } returns listOf(email1, email2)
         every { newsletterService.findNewsletterHandlerForEmail(any()) } returns newsletterHandler
         every { newsletterHandler.process(email1) } returns listOf(publication1)
         every { newsletterHandler.process(email2) } returns listOf(publication2)
@@ -254,12 +267,12 @@ class EmailCheckerTest {
 
         // THEN
         verify(exactly = 0) {
-            emailClient.markAsRead(email1)
-            emailClient.moveToProcessed(match { it.contains(email1) })
+            emailClientSession.markAsRead(email1)
+            emailClientSession.moveToProcessed(match { it.contains(email1) })
         }
         verify {
-            emailClient.markAsRead(email2)
-            emailClient.moveToProcessed(listOf(email2))
+            emailClientSession.markAsRead(email2)
+            emailClientSession.moveToProcessed(listOf(email2))
         }
         verify {
             monitoringService.notifyEmailProcessingError(
@@ -278,13 +291,13 @@ class EmailCheckerTest {
         @MockK publication: Publication,
     ) {
         // GIVEN
-        every { emailClient.checkEmails() } returns listOf(email)
+        every { emailClientSession.checkEmails() } returns listOf(email)
         every { newsletterService.findNewsletterHandlerForEmail(email) } returns newsletterHandler
         every { newsletterHandler.process(email) } returns listOf(publication)
         every { publication.articles } returns listOf(mockk())
 
         val markAsReadError = RuntimeException("TEST")
-        every { emailClient.markAsRead(any()) } throws markAsReadError
+        every { emailClientSession.markAsRead(any()) } throws markAsReadError
         every { monitoringService.notifyGenericError(any(), any()) } just Runs
 
         // WHEN
@@ -293,8 +306,8 @@ class EmailCheckerTest {
         // THEN
         verify { newsletterHandler.process(email) }
         verify { publicationService.savePublications(eq(listOf(publication))) }
-        verify { emailClient.markAsRead(email) }
-        verify(exactly = 0) { emailClient.moveToProcessed(any()) }
+        verify { emailClientSession.markAsRead(email) }
+        verify(exactly = 0) { emailClientSession.moveToProcessed(any()) }
 
         verify { monitoringService.notifyGenericError(markAsReadError, any()) }
         confirmVerified(monitoringService)
@@ -307,13 +320,13 @@ class EmailCheckerTest {
         @MockK publication: Publication,
     ) {
         // GIVEN
-        every { emailClient.checkEmails() } returns listOf(email)
+        every { emailClientSession.checkEmails() } returns listOf(email)
         every { newsletterService.findNewsletterHandlerForEmail(email) } returns newsletterHandler
         every { newsletterHandler.process(email) } returns listOf(publication)
         every { publication.articles } returns listOf(mockk())
 
         val moveToProcessedError = RuntimeException("TEST")
-        every { emailClient.moveToProcessed(any()) } throws moveToProcessedError
+        every { emailClientSession.moveToProcessed(any()) } throws moveToProcessedError
         every { monitoringService.notifyGenericError(any(), any()) } just Runs
 
         // WHEN
@@ -322,8 +335,8 @@ class EmailCheckerTest {
         // THEN
         verify { newsletterHandler.process(email) }
         verify { publicationService.savePublications(eq(listOf(publication))) }
-        verify { emailClient.markAsRead(email) }
-        verify { emailClient.moveToProcessed(listOf(email)) }
+        verify { emailClientSession.markAsRead(email) }
+        verify { emailClientSession.moveToProcessed(listOf(email)) }
 
         verify(exactly = 0) { monitoringService.notifyGenericError(moveToProcessedError, any()) }
         confirmVerified(monitoringService)

--- a/server/src/test/kotlin/fr/nicopico/n2rss/mail/EmailCheckerTest.kt
+++ b/server/src/test/kotlin/fr/nicopico/n2rss/mail/EmailCheckerTest.kt
@@ -314,7 +314,7 @@ class EmailCheckerTest {
     }
 
     @Test
-    fun `emailChecker should NOT report moveToProcessed error as generic error`(
+    fun `emailChecker should report moveToProcessed error as generic error`(
         @MockK(relaxed = true) email: Email,
         @MockK(relaxed = true) newsletterHandler: NewsletterHandler,
         @MockK publication: Publication,
@@ -338,7 +338,7 @@ class EmailCheckerTest {
         verify { emailClientSession.markAsRead(email) }
         verify { emailClientSession.moveToProcessed(listOf(email)) }
 
-        verify(exactly = 0) { monitoringService.notifyGenericError(moveToProcessedError, any()) }
+        verify { monitoringService.notifyGenericError(moveToProcessedError, any()) }
         confirmVerified(monitoringService)
     }
 }

--- a/server/src/test/kotlin/fr/nicopico/n2rss/mail/EmailCheckerTest.kt
+++ b/server/src/test/kotlin/fr/nicopico/n2rss/mail/EmailCheckerTest.kt
@@ -271,7 +271,7 @@ class EmailCheckerTest {
     }
 
     @Test
-    fun `emailChecker should report moveToProcessed error as generic error`(
+    fun `emailChecker should NOT report moveToProcessed error as generic error`(
         @MockK(relaxed = true) email: Email,
         @MockK newsletterHandler: NewsletterHandler,
         @MockK publication: Publication,
@@ -295,7 +295,7 @@ class EmailCheckerTest {
         verify { emailClient.markAsRead(email) }
         verify { emailClient.moveToProcessed(email) }
 
-        verify { monitoringService.notifyGenericError(moveToProcessedError, any()) }
+        verify(exactly = 0) { monitoringService.notifyGenericError(moveToProcessedError, any()) }
         confirmVerified(monitoringService)
     }
 }

--- a/server/src/test/kotlin/fr/nicopico/n2rss/mail/EmailCheckerTest.kt
+++ b/server/src/test/kotlin/fr/nicopico/n2rss/mail/EmailCheckerTest.kt
@@ -23,7 +23,9 @@ import fr.nicopico.n2rss.mail.models.Email
 import fr.nicopico.n2rss.monitoring.MonitoringService
 import fr.nicopico.n2rss.newsletter.handlers.NewsletterHandler
 import fr.nicopico.n2rss.newsletter.handlers.exception.NoPublicationFoundException
+import fr.nicopico.n2rss.newsletter.handlers.newsletters
 import fr.nicopico.n2rss.newsletter.handlers.process
+import fr.nicopico.n2rss.newsletter.models.Newsletter
 import fr.nicopico.n2rss.newsletter.models.Publication
 import fr.nicopico.n2rss.newsletter.service.NewsletterService
 import fr.nicopico.n2rss.newsletter.service.PublicationService
@@ -70,7 +72,7 @@ class EmailCheckerTest {
     @Test
     fun `emailChecker handles email when appropriate handler is present`(
         @MockK(relaxed = true) email: Email,
-        @MockK newsletterHandler: NewsletterHandler,
+        @MockK(relaxed = true) newsletterHandler: NewsletterHandler,
         @MockK publication: Publication,
     ) {
         // Given an email that should be handled by a newsletterHandler
@@ -107,10 +109,38 @@ class EmailCheckerTest {
     }
 
     @Test
+    fun `emailChecker do not process email if the corresponding publication already exists`(
+        @MockK(relaxed = true) email: Email,
+        @MockK newsletterHandler: NewsletterHandler,
+        @MockK newsletter: Newsletter,
+    ) {
+        // Given an email that already exists in the database
+        every { email.subject } returns "Email subject"
+        every { emailClient.checkEmails() } returns listOf(email)
+        every { newsletterService.findNewsletterHandlerForEmail(email) } returns newsletterHandler
+        every { newsletterHandler.newsletters } returns listOf(newsletter)
+        every {
+            publicationService.doesPublicationAlreadyExist(
+                title = "Email subject",
+                newsletters = listOf(newsletter),
+            )
+        } returns true
+
+        // When we check the email
+        emailChecker.savePublicationsFromEmails()
+
+        // Then the email should not be processed again, but the email should be marked
+        verify(exactly = 0) { newsletterHandler.process(email) }
+        verify(exactly = 0) { publicationService.savePublications(any()) }
+        verify { emailClient.markAsRead(email) }
+        verify { emailClient.moveToProcessed(listOf(email)) }
+    }
+
+    @Test
     fun `emailChecker continues processing emails after a processing error`(
         @MockK(relaxed = true) errorEmail: Email,
         @MockK(relaxed = true) validEmail: Email,
-        @MockK newsletterHandler: NewsletterHandler,
+        @MockK(relaxed = true) newsletterHandler: NewsletterHandler,
         @MockK publication: Publication,
     ) {
         // Given an email that causes an error and a valid email
@@ -170,7 +200,7 @@ class EmailCheckerTest {
     @Test
     fun `emailChecker should notify an error on empty publications`(
         @MockK(relaxed = true) email: Email,
-        @MockK newsletterHandler: NewsletterHandler,
+        @MockK(relaxed = true) newsletterHandler: NewsletterHandler,
         @MockK publication: Publication,
     ) {
         // Given an email without any articles
@@ -202,7 +232,7 @@ class EmailCheckerTest {
     fun `emailChecker should not mark emails as read if the publications could not be saved`(
         @MockK(relaxed = true) email1: Email,
         @MockK(relaxed = true) email2: Email,
-        @MockK newsletterHandler: NewsletterHandler,
+        @MockK(relaxed = true) newsletterHandler: NewsletterHandler,
         @MockK(relaxed = true) publication1: Publication,
         @MockK(relaxed = true) publication2: Publication,
     ) {
@@ -244,7 +274,7 @@ class EmailCheckerTest {
     @Test
     fun `emailChecker should report markAsRead error as generic error`(
         @MockK(relaxed = true) email: Email,
-        @MockK newsletterHandler: NewsletterHandler,
+        @MockK(relaxed = true) newsletterHandler: NewsletterHandler,
         @MockK publication: Publication,
     ) {
         // GIVEN
@@ -273,7 +303,7 @@ class EmailCheckerTest {
     @Test
     fun `emailChecker should NOT report moveToProcessed error as generic error`(
         @MockK(relaxed = true) email: Email,
-        @MockK newsletterHandler: NewsletterHandler,
+        @MockK(relaxed = true) newsletterHandler: NewsletterHandler,
         @MockK publication: Publication,
     ) {
         // GIVEN

--- a/server/src/test/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClientTest.kt
+++ b/server/src/test/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClientTest.kt
@@ -83,7 +83,7 @@ class JavaxEmailClientTest : GreenMailTestBase(
         )
 
         // WHEN
-        val emails = emailClient.checkEmails()
+        val emails: List<Email> = emailClient.openSession().use { it.checkEmails() }
 
         // THEN
         emails shouldHaveSize 3
@@ -143,14 +143,18 @@ class JavaxEmailClientTest : GreenMailTestBase(
         )
 
         // WHEN
-        val emails = emailClient.checkEmails()
-        shouldNotThrowAny {
-            emailClient.markAsRead(emails[1])
-            emailClient.markAsRead(emails[3])
+        val emails: List<Email>
+        emailClient.openSession().use { session ->
+            emails = session.checkEmails()
+
+            shouldNotThrowAny {
+                session.markAsRead(emails[1])
+                session.markAsRead(emails[3])
+            }
         }
 
         // THEN
-        val unreadEmails = emailClient.checkEmails()
+        val unreadEmails = emailClient.openSession().use { it.checkEmails() }
         unreadEmails.map { it.subject } shouldBe listOf("Subject 1", "Subject 3")
     }
 
@@ -178,17 +182,16 @@ class JavaxEmailClientTest : GreenMailTestBase(
         )
 
         // Retrieval 1: Open and close folder
-        val emails = emailClient.checkEmails()
-        val email = emails[0]
+        val email = emailClient.openSession().use { it.checkEmails()[0] }
 
         // WHEN
         // Re-open folder and try to mark as read using the old message object
         shouldNotThrowAny {
-            emailClient.markAsRead(email)
+            emailClient.openSession().use { it.markAsRead(email) }
         }
 
         // THEN
-        val unreadEmails = emailClient.checkEmails()
+        val unreadEmails = emailClient.openSession().use { it.checkEmails() }
         unreadEmails shouldHaveSize 0
     }
 
@@ -217,17 +220,16 @@ class JavaxEmailClientTest : GreenMailTestBase(
         )
 
         // Retrieval 1: Open and close folder
-        val emails = emailClient.checkEmails()
-        val email = emails[0]
+        val email = emailClient.openSession().use { it.checkEmails()[0] }
 
         // WHEN
         // Re-open folder and try to move using the old message object
         shouldNotThrowAny {
-            emailClient.moveToProcessed(listOf(email))
+            emailClient.openSession().use { it.moveToProcessed(listOf(email)) }
         }
 
         // THEN
-        val unreadEmails = emailClient.checkEmails()
+        val unreadEmails = emailClient.openSession().use { it.checkEmails() }
         unreadEmails shouldHaveSize 0
     }
 
@@ -261,14 +263,16 @@ class JavaxEmailClientTest : GreenMailTestBase(
         )
 
         // WHEN
-        val emails = emailClient.checkEmails()
-        emails[0].subject shouldBe "Subject 1"
-        emails[3].subject shouldBe "Subject 4"
+        emailClient.openSession().use { session ->
+            val emails = session.checkEmails()
+            emails[0].subject shouldBe "Subject 1"
+            emails[3].subject shouldBe "Subject 4"
 
-        emailClient.moveToProcessed(listOf(emails[0], emails[3]))
+            session.moveToProcessed(listOf(emails[0], emails[3]))
+        }
 
         // THEN
-        val retainedEmails = emailClient.checkEmails()
+        val retainedEmails = emailClient.openSession().use { it.checkEmails() }
         retainedEmails.none {
             it.subject == "Subject 1" || it.subject == "Subject 4"
         }
@@ -304,25 +308,27 @@ class JavaxEmailClientTest : GreenMailTestBase(
         )
 
         // WHEN
-        val emails = emailClient.checkEmails()
-        emails.map { it.subject } shouldBe listOf(
-            "Subject 1",
-            "Subject 2",
-            "Subject 3",
-            "Subject 4",
-        )
+        emailClient.openSession().use { session ->
+            val emails = session.checkEmails()
+            emails.map { it.subject } shouldBe listOf(
+                "Subject 1",
+                "Subject 2",
+                "Subject 3",
+                "Subject 4",
+            )
 
-        // First batch
-        emailClient.markAsRead(emails[0])
-        emailClient.markAsRead(emails[1])
-        emailClient.moveToProcessed(listOf(emails[0], emails[1]))
+            // First batch
+            session.markAsRead(emails[0])
+            session.markAsRead(emails[1])
+            session.moveToProcessed(listOf(emails[0], emails[1]))
 
-        // Second batch
-        emailClient.markAsRead(emails[2])
-        emailClient.moveToProcessed(listOf(emails[2]))
+            // Second batch
+            session.markAsRead(emails[2])
+            session.moveToProcessed(listOf(emails[2]))
+        }
 
         // THEN
-        emailClient.checkEmails() shouldBe singleElement<Email> {
+        emailClient.openSession().use { it.checkEmails() } shouldBe singleElement<Email> {
             it.subject == "Subject 4"
         }
     }

--- a/server/src/test/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClientTest.kt
+++ b/server/src/test/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClientTest.kt
@@ -221,7 +221,7 @@ class JavaxEmailClientTest : GreenMailTestBase(
         // WHEN
         // Re-open folder and try to move using the old message object
         shouldNotThrowAny {
-            emailClient.moveToProcessed(email)
+            emailClient.moveToProcessed(listOf(email))
         }
 
         // THEN
@@ -263,8 +263,7 @@ class JavaxEmailClientTest : GreenMailTestBase(
         emails[0].subject shouldBe "Subject 1"
         emails[3].subject shouldBe "Subject 4"
 
-        emailClient.moveToProcessed(emails[0])
-        emailClient.moveToProcessed(emails[3])
+        emailClient.moveToProcessed(listOf(emails[0], emails[3]))
 
         // THEN
         val retainedEmails = emailClient.checkEmails()

--- a/server/src/test/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClientTest.kt
+++ b/server/src/test/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClientTest.kt
@@ -27,7 +27,6 @@ import io.kotest.matchers.shouldBe
 import jakarta.mail.Flags
 import jakarta.mail.search.FlagTerm
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class JavaxEmailClientTest : GreenMailTestBase(
@@ -159,8 +158,6 @@ class JavaxEmailClientTest : GreenMailTestBase(
         unreadEmails.map { it.subject } shouldBe listOf("Subject 1", "Subject 3")
     }
 
-    // TODO Restore this test
-    @Disabled
     @Test
     fun `markAsRead should handle stale message objects`() {
         // GIVEN
@@ -198,8 +195,6 @@ class JavaxEmailClientTest : GreenMailTestBase(
         unreadEmails shouldHaveSize 0
     }
 
-    // TODO Restore this test
-    @Disabled
     @Test
     fun `moveToProcessed should handle stale message objects`() {
         // GIVEN

--- a/server/src/test/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClientTest.kt
+++ b/server/src/test/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClientTest.kt
@@ -17,10 +17,12 @@
  */
 package fr.nicopico.n2rss.mail.client
 
+import fr.nicopico.n2rss.mail.models.Email
 import fr.nicopico.n2rss.mail.models.EmailContent
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.singleElement
 import io.kotest.matchers.shouldBe
 import jakarta.mail.Flags
 import jakarta.mail.search.FlagTerm
@@ -269,6 +271,59 @@ class JavaxEmailClientTest : GreenMailTestBase(
         val retainedEmails = emailClient.checkEmails()
         retainedEmails.none {
             it.subject == "Subject 1" || it.subject == "Subject 4"
+        }
+    }
+
+    @Test
+    fun `emailClient should handle processing several messages in multiple batches`() {
+        // GIVEN
+        prepareFolders(SECONDARY_FOLDER, TRASH_FOLDER)
+        deliverTextMessage(
+            folderName = INBOX_FOLDER,
+            from = "from@email.com",
+            subject = "Subject 1",
+            content = "Hello World! 1",
+        )
+        deliverTextMessage(
+            folderName = INBOX_FOLDER,
+            from = "from@another-email.com",
+            subject = "Subject 2",
+            content = "Hello World! 2",
+        )
+        deliverTextMessage(
+            folderName = INBOX_FOLDER,
+            from = "from@another-email.com",
+            subject = "Subject 3",
+            content = "Hello World! 3",
+        )
+        deliverTextMessage(
+            folderName = INBOX_FOLDER,
+            from = "from@another-email.com",
+            subject = "Subject 4",
+            content = "Hello World! 4",
+        )
+
+        // WHEN
+        val emails = emailClient.checkEmails()
+        emails.map { it.subject } shouldBe listOf(
+            "Subject 1",
+            "Subject 2",
+            "Subject 3",
+            "Subject 4",
+        )
+
+        // First batch
+        emailClient.markAsRead(emails[0])
+        emailClient.markAsRead(emails[1])
+        emailClient.moveToProcessed(listOf(emails[0], emails[1]))
+
+        // Second batch
+        emailClient.markAsRead(emails[2])
+        emailClient.moveToProcessed(listOf(emails[2]))
+
+        // THEN
+        emailClient.checkEmails() shouldBe singleElement<Email> {
+            it.subject == "Subject 4"
         }
     }
 }

--- a/server/src/test/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClientTest.kt
+++ b/server/src/test/kotlin/fr/nicopico/n2rss/mail/client/JavaxEmailClientTest.kt
@@ -27,6 +27,7 @@ import io.kotest.matchers.shouldBe
 import jakarta.mail.Flags
 import jakarta.mail.search.FlagTerm
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class JavaxEmailClientTest : GreenMailTestBase(
@@ -158,6 +159,8 @@ class JavaxEmailClientTest : GreenMailTestBase(
         unreadEmails.map { it.subject } shouldBe listOf("Subject 1", "Subject 3")
     }
 
+    // TODO Restore this test
+    @Disabled
     @Test
     fun `markAsRead should handle stale message objects`() {
         // GIVEN
@@ -195,6 +198,8 @@ class JavaxEmailClientTest : GreenMailTestBase(
         unreadEmails shouldHaveSize 0
     }
 
+    // TODO Restore this test
+    @Disabled
     @Test
     fun `moveToProcessed should handle stale message objects`() {
         // GIVEN

--- a/server/src/test/kotlin/fr/nicopico/n2rss/mail/client/MessageExtKtTest.kt
+++ b/server/src/test/kotlin/fr/nicopico/n2rss/mail/client/MessageExtKtTest.kt
@@ -232,6 +232,7 @@ class MessageExtKtTest {
     ): Message {
         return mockk<Message> {
             val msg = this
+            every { msg.folder } returns mockk()
             every { msg.messageNumber } returns messageNumber
             every { msg.subject } returns subject
             every { msg.content } returns content

--- a/server/src/test/kotlin/fr/nicopico/n2rss/mail/client/NoOpEmailClientTest.kt
+++ b/server/src/test/kotlin/fr/nicopico/n2rss/mail/client/NoOpEmailClientTest.kt
@@ -42,16 +42,16 @@ class NoOpEmailClientTest {
 
         // WHEN - THEN
         shouldNotThrowAny {
-            emailClient.markAsRead(anyEmail)
+            emailClient.openSession().use {
+                it.markAsRead(anyEmail)
+            }
         }
     }
 
     @Test
     fun checkEmails() {
-        // WHEN
-        val result = emailClient.checkEmails()
-
-        // THEN
-        result should beEmpty()
+        emailClient.openSession().use {
+            it.checkEmails() should beEmpty()
+        }
     }
 }

--- a/server/src/test/kotlin/fr/nicopico/n2rss/newsletter/service/PublicationServiceTest.kt
+++ b/server/src/test/kotlin/fr/nicopico/n2rss/newsletter/service/PublicationServiceTest.kt
@@ -39,6 +39,7 @@ import io.kotest.matchers.types.instanceOf
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.datetime.DatePeriod
@@ -239,6 +240,57 @@ class PublicationServiceTest {
 
         // THEN
         stats shouldBe instanceOf<NoPublication>()
+    }
+
+    @Test
+    fun `should indicate if a publication already exists`() {
+        // GIVEN
+        val publicationTitle = "Some title"
+        val newsletter = createStubNewsletter("code1")
+        val otherNewsletter = createStubNewsletter("code2")
+
+        every {
+            publicationRepository.findFirstByNewsletterCodeAndTitle(
+                newsletterCode = any(),
+                title = publicationTitle,
+            )
+        } answers {
+            val newsletterCode = firstArg<String>()
+            if (newsletterCode == "code2") mockk() else null
+        }
+
+        // WHEN
+        val result = publicationService.doesPublicationAlreadyExist(
+            title = publicationTitle,
+            newsletters = listOf(newsletter, otherNewsletter),
+        )
+
+        // THEN
+        result shouldBe true
+    }
+
+    @Test
+    fun `should indicate if a publication does not exist yet`() {
+        // GIVEN
+        val publicationTitle = "Some title"
+        val newsletter = createStubNewsletter("code1")
+        val otherNewsletter = createStubNewsletter("code2")
+
+        every {
+            publicationRepository.findFirstByNewsletterCodeAndTitle(
+                newsletterCode = any(),
+                title = publicationTitle,
+            )
+        } returns null
+
+        // WHEN
+        val result = publicationService.doesPublicationAlreadyExist(
+            title = publicationTitle,
+            newsletters = listOf(newsletter, otherNewsletter),
+        )
+
+        // THEN
+        result shouldBe false
     }
 
     @Nested


### PR DESCRIPTION
- check if the corresponding publication exists before processing an email
- move emails by batch at the end of the processing
